### PR TITLE
test: Expand LLM orchestration test coverage

### DIFF
--- a/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/domain/usecase/chat/InferenceFlowIntegrationTest.kt
+++ b/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/domain/usecase/chat/InferenceFlowIntegrationTest.kt
@@ -17,6 +17,7 @@
 package com.browntowndev.pocketcrew.domain.usecase.chat
 
 import com.browntowndev.pocketcrew.domain.model.MessageState
+import com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration
 import com.browntowndev.pocketcrew.domain.usecase.FakeInferenceFactory
 import com.browntowndev.pocketcrew.domain.model.chat.Mode
 import com.browntowndev.pocketcrew.domain.model.inference.ModelType
@@ -96,7 +97,7 @@ class InferenceFlowIntegrationTest {
     @Test
     fun `end-to-end flow from InferenceEvent to AccumulatedMessages`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -139,7 +140,7 @@ class InferenceFlowIntegrationTest {
     @Test
     fun `flow completes and persists all messages`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -181,7 +182,7 @@ class InferenceFlowIntegrationTest {
     @Test
     fun `lock acquired on start and released on completion`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -242,7 +243,7 @@ class InferenceFlowIntegrationTest {
     @Test
     fun `error state is accumulated and persisted`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -277,7 +278,7 @@ class InferenceFlowIntegrationTest {
     @Test
     fun `thinking state is accumulated correctly`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -315,7 +316,7 @@ class InferenceFlowIntegrationTest {
     @Test
     fun `ThinkingLive event sets messageState to THINKING`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -350,7 +351,7 @@ class InferenceFlowIntegrationTest {
     @Test
     fun `GeneratingText event sets messageState to GENERATING`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -385,7 +386,7 @@ class InferenceFlowIntegrationTest {
     @Test
     fun `Finished event sets messageState to COMPLETE`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -420,7 +421,7 @@ class InferenceFlowIntegrationTest {
     @Test
     fun `thinkingEndTime is set when GeneratingText first arrives after Thinking`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -460,7 +461,7 @@ class InferenceFlowIntegrationTest {
     @Test
     fun `thinkingEndTime is not overwritten by subsequent GeneratingText`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -514,7 +515,7 @@ class InferenceFlowIntegrationTest {
     @Test
     fun `messageState transitions correctly from THINKING to GENERATING to COMPLETE`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -569,7 +570,7 @@ class InferenceFlowIntegrationTest {
     @Test
     fun `GeneratingText with DRAFT_ONE model sets pipelineStep to DRAFT_ONE`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.DRAFT_ONE) } returns mockConfig
 
         every { thinkingModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -609,7 +610,7 @@ class InferenceFlowIntegrationTest {
     @Test
     fun `GeneratingText with DRAFT_TWO model sets pipelineStep to DRAFT_TWO`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.DRAFT_TWO) } returns mockConfig
 
         every { thinkingModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -649,7 +650,7 @@ class InferenceFlowIntegrationTest {
     @Test
     fun `GeneratingText with MAIN model sets pipelineStep to SYNTHESIS`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.MAIN) } returns mockConfig
 
         every { thinkingModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -689,7 +690,7 @@ class InferenceFlowIntegrationTest {
     @Test
     fun `GeneratingText with FINAL_SYNTHESIS model sets pipelineStep to FINAL`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FINAL_SYNTHESIS) } returns mockConfig
 
         every { thinkingModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -720,4 +721,119 @@ class InferenceFlowIntegrationTest {
         assertNotNull(snapshot)
         assertEquals(PipelineStep.FINAL, snapshot!!.pipelineStep)
     }
+
+
+    // ========================================================================
+    // Test: Model Timeout
+    // Evidence: Ensures state is preserved correctly when a timeout occurs
+    // ========================================================================
+
+    @Test
+    fun `model timeout correctly produces Error state with specific timeout exception`() = runTest {
+        // Given
+        val mockConfig = mockk<ModelConfiguration>()
+        every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
+
+        val exception = Exception("Timed out waiting for model")
+
+        every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
+            InferenceEvent.Error(exception, ModelType.FAST)
+        )
+        coEvery { messageRepository.getMessagesForChat(any()) } returns emptyList()
+
+        // When
+        val accumulatedMessages = mutableListOf<GenerateChatResponseUseCase.AccumulatedMessages>()
+        generateChatResponseUseCase(
+            prompt = "Hello",
+            userMessageId = 1L,
+            assistantMessageId = 2L,
+            chatId = 1L,
+            mode = Mode.FAST
+        ).collect { state ->
+            accumulatedMessages.add(state)
+        }
+
+        // Then
+        assertTrue(accumulatedMessages.isNotEmpty())
+        val finalState = accumulatedMessages.last()
+        val snapshot = finalState.messages[2L]
+        assertNotNull(snapshot)
+        assertEquals(MessageState.COMPLETE, snapshot?.messageState)
+        assertEquals("Error: Timed out waiting for model", snapshot?.content)
+    }
+
+
+    // ========================================================================
+    // Test: Empty Stream Responses
+    // Evidence: Checks whether the pipeline behaves correctly when flow returns zero real events
+    // ========================================================================
+
+    @Test
+    fun `empty stream responses completes gracefully without crashing`() = runTest {
+        // Given
+        val mockConfig = mockk<ModelConfiguration>()
+        every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
+
+        // Flow completes immediately without emitting anything
+        every { fastModelService.sendPrompt(any(), any()) } returns kotlinx.coroutines.flow.emptyFlow()
+        coEvery { messageRepository.getMessagesForChat(any()) } returns emptyList()
+
+        // When
+        val accumulatedMessages = mutableListOf<GenerateChatResponseUseCase.AccumulatedMessages>()
+        generateChatResponseUseCase(
+            prompt = "Empty test",
+            userMessageId = 1L,
+            assistantMessageId = 2L,
+            chatId = 1L,
+            mode = Mode.FAST
+        ).collect { state ->
+            accumulatedMessages.add(state)
+        }
+
+        // Then
+        assertTrue(accumulatedMessages.isEmpty())
+    }
+
+
+    // ========================================================================
+    // Test: Concurrent Agent Failures
+    // Evidence: Verifies that multiple errors in rapid succession update the final state
+    // ========================================================================
+
+    @Test
+    fun `concurrent agent failures process the last error successfully`() = runTest {
+        // Given
+        val mockConfig = mockk<ModelConfiguration>()
+        every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
+
+        val firstException = Exception("Agent 1 failed")
+        val secondException = Exception("Agent 2 failed")
+
+        every { fastModelService.sendPrompt(any(), any()) } returns kotlinx.coroutines.flow.flowOf(
+            InferenceEvent.Error(firstException, ModelType.FAST),
+            InferenceEvent.Error(secondException, ModelType.FAST)
+        )
+        coEvery { messageRepository.getMessagesForChat(any()) } returns emptyList()
+
+        // When
+        val accumulatedMessages = mutableListOf<GenerateChatResponseUseCase.AccumulatedMessages>()
+        generateChatResponseUseCase(
+            prompt = "Crash me",
+            userMessageId = 1L,
+            assistantMessageId = 2L,
+            chatId = 1L,
+            mode = Mode.FAST
+        ).collect { state ->
+            accumulatedMessages.add(state)
+        }
+
+        // Then
+        assertTrue(accumulatedMessages.isNotEmpty())
+        val finalState = accumulatedMessages.last()
+        val snapshot = finalState.messages[2L]
+        assertNotNull(snapshot)
+        assertEquals(MessageState.COMPLETE, snapshot?.messageState)
+        assertEquals("Error: Agent 2 failed", snapshot?.content)
+    }
+
 }

--- a/feature/inference/src/test/kotlin/com/browntowndev/pocketcrew/feature/inference/InferenceFactoryImplTest.kt
+++ b/feature/inference/src/test/kotlin/com/browntowndev/pocketcrew/feature/inference/InferenceFactoryImplTest.kt
@@ -4,6 +4,7 @@ import com.browntowndev.pocketcrew.domain.model.inference.ModelType
 import com.browntowndev.pocketcrew.domain.port.inference.LlmInferencePort
 import com.browntowndev.pocketcrew.domain.port.inference.LoggingPort
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.BeforeEach
@@ -145,4 +146,11 @@ class InferenceFactoryImplTest {
             }
         }
     }
+
+    @Test
+    fun `logs debug message when returning on-device engine`() = runTest {
+        factory.getInferenceService(ModelType.FAST)
+        verify { loggingPort.debug("InferenceFactory", "Resolving FAST → ON_DEVICE (stub)") }
+    }
+
 }

--- a/feature/moa-pipeline-worker/src/test/kotlin/com/browntowndev/pocketcrew/feature/moa/InferenceServicePipelineExecutorTest.kt
+++ b/feature/moa-pipeline-worker/src/test/kotlin/com/browntowndev/pocketcrew/feature/moa/InferenceServicePipelineExecutorTest.kt
@@ -16,8 +16,10 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.slot
+import io.mockk.coEvery
+import io.mockk.mockkObject
 import io.mockk.verify
+import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
@@ -55,7 +57,7 @@ class InferenceServicePipelineExecutorTest {
 
     @Test
     fun `executePipeline forwards thinking chunks with newlines and spaces`() = runTest {
-        io.mockk.mockkObject(PipelineState.Companion)
+        mockkObject(PipelineState.Companion)
         val mockState = mockk<PipelineState>()
         every { mockState.toJson() } returns "{}"
         every { mockState.currentStep } returns PipelineStep.DRAFT_ONE
@@ -129,7 +131,7 @@ class InferenceServicePipelineExecutorTest {
 
     @Test
     fun `executePipeline forwards step output chunks with newlines and spaces`() = runTest {
-        io.mockk.mockkObject(PipelineState.Companion)
+        mockkObject(PipelineState.Companion)
         val mockState = mockk<PipelineState>()
         every { mockState.toJson() } returns "{}"
         every { mockState.currentStep } returns PipelineStep.DRAFT_ONE
@@ -203,13 +205,13 @@ class InferenceServicePipelineExecutorTest {
 
     @Test
     fun `resumeFromState forwards thinking chunks with newlines and spaces`() = runTest {
-        io.mockk.mockkObject(PipelineState.Companion)
+        mockkObject(PipelineState.Companion)
         val mockState = mockk<PipelineState>()
         every { mockState.toJson() } returns "{}"
         every { mockState.currentStep } returns PipelineStep.DRAFT_ONE
         
         // Mock the repository to return the state
-        io.mockk.coEvery { pipelineStateRepository.getPipelineState(any()) } returns mockState
+        coEvery { pipelineStateRepository.getPipelineState(any()) } returns mockState
 
         val receiverSlot = slot<BroadcastReceiver>()
         every {
@@ -255,4 +257,50 @@ class InferenceServicePipelineExecutorTest {
         assertEquals(1, thinkingEvents.size)
         assertEquals("\n", thinkingEvents[0].thinkingChunk)
     }
+
+    @Test
+    fun `executePipeline handles broadcast error and forwards it successfully`() = runTest {
+        mockkObject(PipelineState.Companion)
+        val mockState = mockk<PipelineState>()
+        every { mockState.toJson() } returns "{}"
+        every { mockState.currentStep } returns PipelineStep.DRAFT_ONE
+        every { PipelineState.createInitial(any(), any()) } returns mockState
+
+        val receiverSlot = slot<BroadcastReceiver>()
+        every {
+            context.registerReceiver(
+                capture(receiverSlot),
+                any<IntentFilter>(),
+                eq(Context.RECEIVER_NOT_EXPORTED)
+            )
+        } returns null
+
+        val events = mutableListOf<MessageGenerationState>()
+
+        val job = launch {
+            executor.executePipeline("chat1", "Hello").collect { state ->
+                events.add(state)
+            }
+        }
+
+        advanceUntilIdle()
+
+        val receiver = receiverSlot.captured
+
+        // Simulate receiving an error broadcast
+        val intentError = mockk<Intent>()
+        every { intentError.action } returns InferenceService.BROADCAST_ERROR
+        every { intentError.getStringExtra(InferenceService.EXTRA_ERROR_MESSAGE) } returns "Mock pipeline error"
+        every { intentError.getStringExtra(InferenceService.EXTRA_MODEL_TYPE) } returns ModelType.MAIN.name
+        receiver.onReceive(context, intentError)
+
+        job.join()
+
+        // We expect an error state
+        val errorEvents = events.filterIsInstance<MessageGenerationState.Failed>()
+        assertEquals(1, errorEvents.size)
+        assertEquals("Mock pipeline error", errorEvents[0].error.message)
+        assertEquals(ModelType.MAIN, errorEvents[0].modelType)
+    }
+
 }


### PR DESCRIPTION
- Add tests for model timeout, empty stream responses, and concurrent
  agent failures in `InferenceFlowIntegrationTest.kt`.
- Add test for broadcast errors in
  `InferenceServicePipelineExecutorTest.kt`.
- Add logging verification test in `InferenceFactoryImplTest.kt`.
- Ensure tests run with `runTest` and use existing MockK/JUnit
  assertion patterns without adding new libraries.

---
*PR created automatically by Jules for task [3209347090991912829](https://jules.google.com/task/3209347090991912829) started by @sean-brown-dev*