### PR TITLE
Refactor: Replace FQNs with Imports

### DIFF
--- a/app/src/main/kotlin/com/browntowndev/pocketcrew/PocketCrewApplication.kt
+++ b/app/src/main/kotlin/com/browntowndev/pocketcrew/PocketCrewApplication.kt
@@ -1,11 +1,12 @@
 package com.browntowndev.pocketcrew
-
 import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import com.google.ai.edge.litertlm.ExperimentalApi
 import com.google.ai.edge.litertlm.ExperimentalFlags
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
+
 
 @HiltAndroidApp
 class PocketCrewApplication : Application(), Configuration.Provider {
@@ -13,7 +14,7 @@ class PocketCrewApplication : Application(), Configuration.Provider {
     @Inject
     lateinit var workerFactory: HiltWorkerFactory
 
-    @OptIn(com.google.ai.edge.litertlm.ExperimentalApi::class)
+    @OptIn(ExperimentalApi::class)
     override fun onCreate() {
         super.onCreate()
         

--- a/app/src/main/kotlin/com/browntowndev/pocketcrew/app/DownloadModule.kt
+++ b/app/src/main/kotlin/com/browntowndev/pocketcrew/app/DownloadModule.kt
@@ -1,5 +1,5 @@
 package com.browntowndev.pocketcrew.app
-
+import com.browntowndev.pocketcrew.core.data.repository.ModelConfigProviderImpl
 import com.browntowndev.pocketcrew.domain.model.download.ModelConfig
 import com.browntowndev.pocketcrew.domain.port.repository.ModelConfigProvider
 import dagger.Binds
@@ -8,6 +8,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
+
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -27,6 +28,6 @@ abstract class DownloadPortModule {
     @Binds
     @Singleton
     abstract fun bindModelConfigProvider(
-        modelConfigProviderImpl: com.browntowndev.pocketcrew.core.data.repository.ModelConfigProviderImpl
+        modelConfigProviderImpl: ModelConfigProviderImpl
     ): ModelConfigProvider
 }

--- a/app/src/main/kotlin/com/browntowndev/pocketcrew/app/EngineModule.kt
+++ b/app/src/main/kotlin/com/browntowndev/pocketcrew/app/EngineModule.kt
@@ -1,32 +1,34 @@
 package com.browntowndev.pocketcrew.app
-
 import android.content.Context
 import android.util.Log
 import com.browntowndev.pocketcrew.domain.model.download.ModelConfig
-import com.browntowndev.pocketcrew.domain.model.inference.ModelType
-import com.browntowndev.pocketcrew.domain.model.inference.FastModelEngine
-import com.browntowndev.pocketcrew.domain.model.inference.ThinkingModelEngine
-import com.browntowndev.pocketcrew.domain.model.inference.MainModelEngine
-import com.browntowndev.pocketcrew.domain.model.inference.VisionModelEngine
 import com.browntowndev.pocketcrew.domain.model.inference.DraftOneModelEngine
 import com.browntowndev.pocketcrew.domain.model.inference.DraftTwoModelEngine
+import com.browntowndev.pocketcrew.domain.model.inference.FastModelEngine
 import com.browntowndev.pocketcrew.domain.model.inference.FinalSynthesizerModelEngine
+import com.browntowndev.pocketcrew.domain.model.inference.LlamaSamplingConfig
+import com.browntowndev.pocketcrew.domain.model.inference.MainModelEngine
+import com.browntowndev.pocketcrew.domain.model.inference.ModelType
+import com.browntowndev.pocketcrew.domain.model.inference.ThinkingModelEngine
+import com.browntowndev.pocketcrew.domain.model.inference.VisionModelEngine
 import com.browntowndev.pocketcrew.domain.port.inference.ConversationManagerPort
-import com.browntowndev.pocketcrew.domain.port.repository.ModelRegistryPort
-import com.browntowndev.pocketcrew.feature.inference.ConversationManagerImpl
+import com.browntowndev.pocketcrew.domain.port.inference.InferenceFactoryPort
 import com.browntowndev.pocketcrew.domain.port.inference.LlmInferencePort
+import com.browntowndev.pocketcrew.domain.port.inference.LoggingPort
+import com.browntowndev.pocketcrew.domain.port.repository.ModelRegistryPort
+import com.browntowndev.pocketcrew.domain.usecase.chat.ProcessThinkingTokensUseCase
+import com.browntowndev.pocketcrew.feature.inference.ConversationManagerImpl
+import com.browntowndev.pocketcrew.feature.inference.InferenceFactoryImpl
 import com.browntowndev.pocketcrew.feature.inference.LiteRtInferenceServiceImpl
 import com.browntowndev.pocketcrew.feature.inference.LlamaInferenceServiceImpl
-import com.browntowndev.pocketcrew.feature.inference.MediaPipeInferenceServiceImpl
 import com.browntowndev.pocketcrew.feature.inference.LlmInferenceWrapper
+import com.browntowndev.pocketcrew.feature.inference.MediaPipeInferenceServiceImpl
 import com.browntowndev.pocketcrew.feature.inference.llama.GpuConfig
 import com.browntowndev.pocketcrew.feature.inference.llama.LlamaChatSessionManager
-import com.browntowndev.pocketcrew.domain.model.inference.LlamaSamplingConfig
-import com.browntowndev.pocketcrew.domain.port.inference.LoggingPort
-import com.browntowndev.pocketcrew.domain.usecase.chat.ProcessThinkingTokensUseCase
 import com.google.ai.edge.litertlm.Backend
 import com.google.ai.edge.litertlm.Engine
 import com.google.ai.edge.litertlm.EngineConfig
+import com.google.ai.edge.litertlm.ExperimentalApi
 import com.google.mediapipe.tasks.genai.llminference.LlmInference
 import dagger.Module
 import dagger.Provides
@@ -35,6 +37,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import java.io.File
 import javax.inject.Singleton
+
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -84,7 +87,7 @@ object EngineModule {
     /**
      * Creates LiteRT Engine using explicit GPU preference.
      */
-    @OptIn(com.google.ai.edge.litertlm.ExperimentalApi::class)
+    @OptIn(ExperimentalApi::class)
     private fun createEngine(modelPath: String): Engine {
         Log.i(TAG, "Creating LiteRT Engine with GPU backend (NPU flags initialized in Application).")
 
@@ -475,6 +478,6 @@ object EngineModule {
     @Provides
     @Singleton
     fun provideInferenceFactory(
-        impl: com.browntowndev.pocketcrew.feature.inference.InferenceFactoryImpl
-    ): com.browntowndev.pocketcrew.domain.port.inference.InferenceFactoryPort = impl
+        impl: InferenceFactoryImpl
+    ): InferenceFactoryPort = impl
 }

--- a/app/src/test/kotlin/com/browntowndev/pocketcrew/app/EngineModuleTest.kt
+++ b/app/src/test/kotlin/com/browntowndev/pocketcrew/app/EngineModuleTest.kt
@@ -1,6 +1,6 @@
 package com.browntowndev.pocketcrew.app
-
 import android.content.Context
+import com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration
 import com.browntowndev.pocketcrew.domain.model.inference.ModelType
 import com.browntowndev.pocketcrew.domain.port.repository.ModelRegistryPort
 import io.mockk.every
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+
 
 /**
  * Tests for EngineModule model provider behavior.
@@ -32,7 +33,7 @@ class EngineModuleTest {
         every { mockRegistry.getRegisteredModelSync(ModelType.DRAFT_ONE) } returns null
         every { mockRegistry.getRegisteredModelSync(ModelType.DRAFT_TWO) } returns null
 
-        val fastConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val fastConfig = mockk<ModelConfiguration>()
         every { fastConfig.metadata } returns mockk {
             every { localFileName } returns "fast.bin"
         }

--- a/app/src/test/kotlin/com/browntowndev/pocketcrew/testing/Fakes.kt
+++ b/app/src/test/kotlin/com/browntowndev/pocketcrew/testing/Fakes.kt
@@ -15,10 +15,10 @@
  */
 
 package com.browntowndev.pocketcrew.testing
-
 import com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration
 import com.browntowndev.pocketcrew.domain.model.config.ModelStatus
 import com.browntowndev.pocketcrew.domain.model.download.DownloadModelsResult
+import com.browntowndev.pocketcrew.domain.model.download.DownloadProgressUpdate
 import com.browntowndev.pocketcrew.domain.model.download.DownloadState
 import com.browntowndev.pocketcrew.domain.model.download.DownloadStatus
 import com.browntowndev.pocketcrew.domain.model.download.FileProgress
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
+
 
 class FakeModelDownloadOrchestrator : ModelDownloadOrchestratorPort {
     private val _downloadState = MutableStateFlow(DownloadState(status = DownloadStatus.CHECKING))
@@ -112,7 +113,7 @@ class FakeModelDownloadOrchestrator : ModelDownloadOrchestratorPort {
         return startDownloads(modelsResult, wifiOnly)
     }
 
-    override suspend fun updateFromProgressUpdate(progressUpdate: com.browntowndev.pocketcrew.domain.model.download.DownloadProgressUpdate) { /* no-op */ }
+    override suspend fun updateFromProgressUpdate(progressUpdate: DownloadProgressUpdate) { /* no-op */ }
 
     override fun pauseDownloads() {
         _downloadState.value = _downloadState.value.copy(status = DownloadStatus.PAUSED)

--- a/core/data/src/main/kotlin/com/browntowndev/pocketcrew/core/data/DataModule.kt
+++ b/core/data/src/main/kotlin/com/browntowndev/pocketcrew/core/data/DataModule.kt
@@ -1,5 +1,5 @@
 package com.browntowndev.pocketcrew.core.data
-
+import android.app.NotificationManager
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
@@ -17,35 +17,43 @@ import com.browntowndev.pocketcrew.core.data.download.ModelConfigFetcherImpl
 import com.browntowndev.pocketcrew.core.data.download.ModelDownloadOrchestratorImpl
 import com.browntowndev.pocketcrew.core.data.download.ModelFileScanner
 import com.browntowndev.pocketcrew.core.data.download.WorkProgressParser
-import com.browntowndev.pocketcrew.core.data.download.remote.HuggingFaceModelUrlProvider
 import com.browntowndev.pocketcrew.core.data.download.remote.HttpFileDownloader
+import com.browntowndev.pocketcrew.core.data.download.remote.HuggingFaceModelUrlProvider
+import com.browntowndev.pocketcrew.core.data.local.ApiModelsDao
 import com.browntowndev.pocketcrew.core.data.local.ChatDao
+import com.browntowndev.pocketcrew.core.data.local.DefaultModelsDao
 import com.browntowndev.pocketcrew.core.data.local.MessageDao
 import com.browntowndev.pocketcrew.core.data.local.ModelsDao
 import com.browntowndev.pocketcrew.core.data.local.PocketCrewDatabase
+import com.browntowndev.pocketcrew.core.data.repository.ApiModelRepositoryImpl
 import com.browntowndev.pocketcrew.core.data.repository.ChatRepositoryImpl
+import com.browntowndev.pocketcrew.core.data.repository.DefaultModelRepositoryImpl
 import com.browntowndev.pocketcrew.core.data.repository.DeviceEnvironmentRepository
 import com.browntowndev.pocketcrew.core.data.repository.MessageRepositoryImpl
 import com.browntowndev.pocketcrew.core.data.repository.ModelConfigProviderImpl
 import com.browntowndev.pocketcrew.core.data.repository.ModelRegistryImpl
+import com.browntowndev.pocketcrew.core.data.repository.PipelineStateRepositoryImpl
 import com.browntowndev.pocketcrew.core.data.repository.RoomTransactionProvider
 import com.browntowndev.pocketcrew.core.data.repository.SettingsRepositoryImpl
-import com.browntowndev.pocketcrew.core.data.repository.PipelineStateRepositoryImpl
 import com.browntowndev.pocketcrew.domain.port.download.DownloadSpeedTrackerPort
 import com.browntowndev.pocketcrew.domain.port.download.FileDownloaderPort
 import com.browntowndev.pocketcrew.domain.port.download.HashingPort
-import com.browntowndev.pocketcrew.domain.qualifier.PipelineDataStore
 import com.browntowndev.pocketcrew.domain.port.download.ModelDownloadOrchestratorPort
 import com.browntowndev.pocketcrew.domain.port.download.ModelFileScannerPort
 import com.browntowndev.pocketcrew.domain.port.download.ModelUrlProviderPort
+import com.browntowndev.pocketcrew.domain.port.inference.LoggingPort
+import com.browntowndev.pocketcrew.domain.port.repository.ApiModelRepositoryPort
 import com.browntowndev.pocketcrew.domain.port.repository.ChatRepository
+import com.browntowndev.pocketcrew.domain.port.repository.DefaultModelRepositoryPort
 import com.browntowndev.pocketcrew.domain.port.repository.DeviceEnvironmentRepositoryPort
 import com.browntowndev.pocketcrew.domain.port.repository.MessageRepository
+import com.browntowndev.pocketcrew.domain.port.repository.ModelConfigFetcherPort
 import com.browntowndev.pocketcrew.domain.port.repository.ModelConfigProvider
 import com.browntowndev.pocketcrew.domain.port.repository.ModelRegistryPort
 import com.browntowndev.pocketcrew.domain.port.repository.PipelineStateRepository
 import com.browntowndev.pocketcrew.domain.port.repository.SettingsRepository
 import com.browntowndev.pocketcrew.domain.port.repository.TransactionProvider
+import com.browntowndev.pocketcrew.domain.qualifier.PipelineDataStore
 import com.browntowndev.pocketcrew.domain.util.Clock
 import com.browntowndev.pocketcrew.domain.util.SystemClock
 import dagger.Binds
@@ -54,8 +62,9 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import okhttp3.OkHttpClient
 import javax.inject.Singleton
+import okhttp3.OkHttpClient
+
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
 private val Context.pipelineDataStore: DataStore<Preferences> by preferencesDataStore(name = "pipeline_state")
@@ -85,10 +94,10 @@ object DataModule {
     fun provideModelsDao(database: PocketCrewDatabase): ModelsDao = database.modelsDao()
 
     @Provides
-    fun provideApiModelsDao(database: PocketCrewDatabase): com.browntowndev.pocketcrew.core.data.local.ApiModelsDao = database.apiModelsDao()
+    fun provideApiModelsDao(database: PocketCrewDatabase): ApiModelsDao = database.apiModelsDao()
 
     @Provides
-    fun provideDefaultModelsDao(database: PocketCrewDatabase): com.browntowndev.pocketcrew.core.data.local.DefaultModelsDao = database.defaultModelsDao()
+    fun provideDefaultModelsDao(database: PocketCrewDatabase): DefaultModelsDao = database.defaultModelsDao()
 
     @Provides
     @Singleton
@@ -106,7 +115,7 @@ object DataModule {
     @Provides
     @Singleton
     fun provideNotificationManager(@ApplicationContext context: Context): DownloadNotificationManager {
-        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         return DownloadNotificationManager(context, notificationManager)
     }
 
@@ -130,7 +139,7 @@ object DataModule {
 
     @Provides
     @Singleton
-    fun provideHttpFileDownloader(okHttpClient: OkHttpClient, logger: com.browntowndev.pocketcrew.domain.port.inference.LoggingPort): FileDownloaderPort = HttpFileDownloader(okHttpClient, logger)
+    fun provideHttpFileDownloader(okHttpClient: OkHttpClient, logger: LoggingPort): FileDownloaderPort = HttpFileDownloader(okHttpClient, logger)
 
     @Provides
     @Singleton
@@ -183,13 +192,13 @@ abstract class DataRepositoryModule {
 
     @Binds
     @Singleton
-    abstract fun bindModelConfigFetcher(impl: ModelConfigFetcherImpl): com.browntowndev.pocketcrew.domain.port.repository.ModelConfigFetcherPort
+    abstract fun bindModelConfigFetcher(impl: ModelConfigFetcherImpl): ModelConfigFetcherPort
 
     @Binds
     @Singleton
-    abstract fun bindDefaultModelRepository(impl: com.browntowndev.pocketcrew.core.data.repository.DefaultModelRepositoryImpl): com.browntowndev.pocketcrew.domain.port.repository.DefaultModelRepositoryPort
+    abstract fun bindDefaultModelRepository(impl: DefaultModelRepositoryImpl): DefaultModelRepositoryPort
 
     @Binds
     @Singleton
-    abstract fun bindApiModelRepository(impl: com.browntowndev.pocketcrew.core.data.repository.ApiModelRepositoryImpl): com.browntowndev.pocketcrew.domain.port.repository.ApiModelRepositoryPort
+    abstract fun bindApiModelRepository(impl: ApiModelRepositoryImpl): ApiModelRepositoryPort
 }

--- a/core/data/src/main/kotlin/com/browntowndev/pocketcrew/core/data/download/DownloadNotificationManager.kt
+++ b/core/data/src/main/kotlin/com/browntowndev/pocketcrew/core/data/download/DownloadNotificationManager.kt
@@ -1,11 +1,10 @@
 package com.browntowndev.pocketcrew.core.data.download
-
 import android.Manifest
 import android.app.Notification
-import android.content.Context
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
+import android.content.Context
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import android.graphics.drawable.Icon
@@ -13,6 +12,8 @@ import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.work.ForegroundInfo
+import java.util.Locale
+
 
 class DownloadNotificationManager(
     private val context: Context,
@@ -89,7 +90,7 @@ class DownloadNotificationManager(
         cancelPendingIntent: PendingIntent
     ): ForegroundInfo {
         val speedString = if (snapshot.currentSpeedMBps > 0) {
-            String.format(java.util.Locale.US, "%.1f MB/s", snapshot.currentSpeedMBps)
+            String.format(Locale.US, "%.1f MB/s", snapshot.currentSpeedMBps)
         } else ""
 
         val etaString = formatEta(snapshot.etaSeconds)

--- a/core/data/src/main/kotlin/com/browntowndev/pocketcrew/core/data/download/ModelDownloadOrchestratorImpl.kt
+++ b/core/data/src/main/kotlin/com/browntowndev/pocketcrew/core/data/download/ModelDownloadOrchestratorImpl.kt
@@ -1,12 +1,12 @@
 package com.browntowndev.pocketcrew.core.data.download
-
 import android.content.Context
-import com.browntowndev.pocketcrew.domain.model.download.DownloadState
+import com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration
+import com.browntowndev.pocketcrew.domain.model.config.ModelStatus
+import com.browntowndev.pocketcrew.domain.model.download.DownloadModelsResult
 import com.browntowndev.pocketcrew.domain.model.download.DownloadProgressUpdate
+import com.browntowndev.pocketcrew.domain.model.download.DownloadState
 import com.browntowndev.pocketcrew.domain.model.download.DownloadStatus
 import com.browntowndev.pocketcrew.domain.model.download.ModelConfig
-import com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration
-import com.browntowndev.pocketcrew.domain.model.download.DownloadModelsResult
 import com.browntowndev.pocketcrew.domain.port.download.DownloadSpeedTrackerPort
 import com.browntowndev.pocketcrew.domain.port.download.ModelDownloadOrchestratorPort
 import com.browntowndev.pocketcrew.domain.port.inference.LoggingPort
@@ -15,12 +15,13 @@ import com.browntowndev.pocketcrew.domain.usecase.download.CheckModelEligibility
 import com.browntowndev.pocketcrew.domain.usecase.download.InitializeFileProgressUseCase
 import com.browntowndev.pocketcrew.domain.usecase.download.ValidateDownloadConditionsUseCase
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
 
 @Singleton
 class ModelDownloadOrchestratorImpl @Inject constructor(
@@ -161,7 +162,7 @@ class ModelDownloadOrchestratorImpl @Inject constructor(
             try {
                 modelRegistry.setRegisteredModel(
                     model,
-                    com.browntowndev.pocketcrew.domain.model.config.ModelStatus.CURRENT,
+                    ModelStatus.CURRENT,
                     markExistingAsOld = false
                 )
                 logger.debug(TAG, "Updated registry: ${model.modelType} -> ${model.metadata.displayName}")

--- a/core/data/src/main/kotlin/com/browntowndev/pocketcrew/core/data/repository/ChatRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/browntowndev/pocketcrew/core/data/repository/ChatRepositoryImpl.kt
@@ -1,22 +1,23 @@
 package com.browntowndev.pocketcrew.core.data.repository
-
 import com.browntowndev.pocketcrew.core.data.local.ChatDao
 import com.browntowndev.pocketcrew.core.data.local.MessageDao
+import com.browntowndev.pocketcrew.core.data.local.MessageEntity
 import com.browntowndev.pocketcrew.core.data.mapper.toDomain
 import com.browntowndev.pocketcrew.core.data.mapper.toEntity
 import com.browntowndev.pocketcrew.core.data.util.FtsSanitizer
+import com.browntowndev.pocketcrew.domain.model.MessageState
 import com.browntowndev.pocketcrew.domain.model.chat.Chat
 import com.browntowndev.pocketcrew.domain.model.chat.Message
+import com.browntowndev.pocketcrew.domain.model.chat.Role
 import com.browntowndev.pocketcrew.domain.model.chat.ThinkingData
 import com.browntowndev.pocketcrew.domain.model.inference.ModelType
 import com.browntowndev.pocketcrew.domain.model.inference.PipelineStep
-import com.browntowndev.pocketcrew.domain.model.MessageState
-import com.browntowndev.pocketcrew.domain.model.chat.Role
 import com.browntowndev.pocketcrew.domain.port.repository.ChatRepository
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
 
 @Singleton
 class ChatRepositoryImpl @Inject constructor(
@@ -91,7 +92,7 @@ class ChatRepositoryImpl @Inject constructor(
         modelType: ModelType,
         pipelineStep: PipelineStep?
     ): Long {
-        val entity = com.browntowndev.pocketcrew.core.data.local.MessageEntity(
+        val entity = MessageEntity(
             chatId = chatId,
             content = "",
             role = Role.ASSISTANT,

--- a/core/data/src/test/kotlin/com/browntowndev/pocketcrew/core/data/download/DownloadNotificationManagerTest.kt
+++ b/core/data/src/test/kotlin/com/browntowndev/pocketcrew/core/data/download/DownloadNotificationManagerTest.kt
@@ -1,7 +1,8 @@
 package com.browntowndev.pocketcrew.core.data.download
-
 import android.app.Notification
+import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
 import androidx.work.ForegroundInfo
 import io.mockk.mockk
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+
 
 @Disabled("Requires Android runtime - use Robolectric for full testing")
 class DownloadNotificationManagerTest {
@@ -29,7 +31,7 @@ class DownloadNotificationManagerTest {
 
     @Test
     fun createNotificationChannel_createsChannelWithCorrectSettings() {
-        val channelSlot = slot<android.app.NotificationChannel>()
+        val channelSlot = slot<NotificationChannel>()
 
         notificationManager.createNotificationChannel()
 
@@ -39,7 +41,7 @@ class DownloadNotificationManagerTest {
 
     @Test
     fun createForegroundInfo_returnsValidForegroundInfo() {
-        val mockPendingIntent = mockk<android.app.PendingIntent>(relaxed = true)
+        val mockPendingIntent = mockk<PendingIntent>(relaxed = true)
 
         val foregroundInfo = notificationManager.createForegroundInfo(mockPendingIntent)
 
@@ -109,7 +111,7 @@ class DownloadNotificationManagerTest {
 
     @Test
     fun createNotification_handlesCancelAction() {
-        val mockPendingIntent = mockk<android.app.PendingIntent>(relaxed = true)
+        val mockPendingIntent = mockk<PendingIntent>(relaxed = true)
 
         val notificationSlot = slot<Notification>()
 

--- a/core/data/src/test/kotlin/com/browntowndev/pocketcrew/core/data/download/DownloadProgressTrackerTest.kt
+++ b/core/data/src/test/kotlin/com/browntowndev/pocketcrew/core/data/download/DownloadProgressTrackerTest.kt
@@ -1,18 +1,19 @@
 package com.browntowndev.pocketcrew.core.data.download
-
-import com.browntowndev.pocketcrew.domain.model.download.FileStatus
 import com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration
+import com.browntowndev.pocketcrew.domain.model.download.FileStatus
 import com.browntowndev.pocketcrew.domain.model.inference.ModelFileFormat
 import com.browntowndev.pocketcrew.domain.model.inference.ModelType
 import com.browntowndev.pocketcrew.domain.port.download.DownloadSpeedTrackerPort
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+
 
 class DownloadProgressTrackerTest {
 
@@ -108,7 +109,7 @@ class DownloadProgressTrackerTest {
     fun updateFileState_throwsForUnknownFile() {
         tracker.initialize(listOf(createModelFile("main.litertlm", 1000L, sha256 = "sha256_main")))
 
-        val exception = org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException::class.java) {
+        val exception = Assertions.assertThrows(IllegalStateException::class.java) {
             tracker.updateFileState("unknown_sha256") { state ->
                 state.copy(status = FileStatus.DOWNLOADING)
             }

--- a/core/data/src/test/kotlin/com/browntowndev/pocketcrew/core/data/download/ModelDownloadOrchestratorImplTest.kt
+++ b/core/data/src/test/kotlin/com/browntowndev/pocketcrew/core/data/download/ModelDownloadOrchestratorImplTest.kt
@@ -1,9 +1,7 @@
 package com.browntowndev.pocketcrew.core.data.download
-
-import org.junit.jupiter.api.extension.RegisterExtension
-import com.browntowndev.pocketcrew.core.testing.MainDispatcherRule
 import android.content.Context
 import android.util.Log
+import com.browntowndev.pocketcrew.core.testing.MainDispatcherRule
 import com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration
 import com.browntowndev.pocketcrew.domain.model.config.ModelStatus
 import com.browntowndev.pocketcrew.domain.model.download.DownloadModelsResult
@@ -14,6 +12,9 @@ import com.browntowndev.pocketcrew.domain.model.inference.ModelType
 import com.browntowndev.pocketcrew.domain.port.download.DownloadSpeedTrackerPort
 import com.browntowndev.pocketcrew.domain.port.inference.LoggingPort
 import com.browntowndev.pocketcrew.domain.port.repository.ModelRegistryPort
+import com.browntowndev.pocketcrew.domain.usecase.download.FileProgressInitResult
+import com.browntowndev.pocketcrew.domain.usecase.download.InitializeFileProgressUseCase
+import com.browntowndev.pocketcrew.domain.usecase.download.ValidateDownloadConditionsUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -22,14 +23,16 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import java.io.File
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
-import java.io.File
+
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ModelDownloadOrchestratorImplTest {
@@ -44,8 +47,8 @@ class ModelDownloadOrchestratorImplTest {
 
     private lateinit var mockContext: Context
     private lateinit var mockSessionManager: DownloadSessionManager
-    private lateinit var mockValidateConditions: com.browntowndev.pocketcrew.domain.usecase.download.ValidateDownloadConditionsUseCase
-    private lateinit var mockInitializeFileProgress: com.browntowndev.pocketcrew.domain.usecase.download.InitializeFileProgressUseCase
+    private lateinit var mockValidateConditions: ValidateDownloadConditionsUseCase
+    private lateinit var mockInitializeFileProgress: InitializeFileProgressUseCase
     private lateinit var mockWorkScheduler: DownloadWorkScheduler
     private lateinit var mockProgressParser: WorkProgressParser
     private lateinit var mockModelRegistry: ModelRegistryPort
@@ -179,7 +182,7 @@ class ModelDownloadOrchestratorImplTest {
         coEvery { mockValidateConditions.invoke(any(), any()) } returns mockk {
             every { canStart } returns true
         }
-        coEvery { mockInitializeFileProgress.invoke(any(), any(), any()) } returns com.browntowndev.pocketcrew.domain.usecase.download.FileProgressInitResult(
+        coEvery { mockInitializeFileProgress.invoke(any(), any(), any()) } returns FileProgressInitResult(
             fileProgressList = emptyList(),
             modelsTotal = 0,
             modelsComplete = 0,

--- a/core/data/src/test/kotlin/com/browntowndev/pocketcrew/core/data/download/remote/HttpFileDownloaderTest.kt
+++ b/core/data/src/test/kotlin/com/browntowndev/pocketcrew/core/data/download/remote/HttpFileDownloaderTest.kt
@@ -1,11 +1,15 @@
 package com.browntowndev.pocketcrew.core.data.download.remote
-
 import com.browntowndev.pocketcrew.domain.port.download.FileDownloaderPort
 import com.browntowndev.pocketcrew.domain.port.inference.LoggingPort
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -17,10 +21,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import java.io.File
-import java.io.IOException
-import java.nio.charset.StandardCharsets
-import java.security.MessageDigest
+
 
 class HttpFileDownloaderTest {
 
@@ -642,7 +643,7 @@ class HttpFileDownloaderTest {
         val mockCall = mockk<okhttp3.Call>(relaxed = true)
         val mockResponse = mockk<Response>(relaxed = true)
         val mockBody = mockk<ResponseBody>(relaxed = true)
-        val failingInputStream = object : java.io.InputStream() {
+        val failingInputStream = object : InputStream() {
             private var readCount = 0
             override fun read(): Int {
                 readCount++

--- a/core/domain/src/main/kotlin/com/browntowndev/pocketcrew/domain/port/inference/ConversationManagerPort.kt
+++ b/core/domain/src/main/kotlin/com/browntowndev/pocketcrew/domain/port/inference/ConversationManagerPort.kt
@@ -1,4 +1,5 @@
 package com.browntowndev.pocketcrew.domain.port.inference
+import com.browntowndev.pocketcrew.domain.model.chat.ChatMessage
 
 /**
  * Domain port for managing LLM conversation lifecycle.
@@ -28,7 +29,7 @@ interface ConversationManagerPort {
      *
      * @param messages The list of historical messages.
      */
-    fun setHistory(messages: List<com.browntowndev.pocketcrew.domain.model.chat.ChatMessage>)
+    fun setHistory(messages: List<ChatMessage>)
 
     /**
      * Closes the underlying engine and releases all resources.

--- a/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/domain/usecase/FakeChatRepository.kt
+++ b/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/domain/usecase/FakeChatRepository.kt
@@ -1,5 +1,4 @@
 package com.browntowndev.pocketcrew.domain.usecase
-
 import com.browntowndev.pocketcrew.domain.model.MessageState
 import com.browntowndev.pocketcrew.domain.model.chat.Chat
 import com.browntowndev.pocketcrew.domain.model.chat.Message
@@ -10,6 +9,8 @@ import com.browntowndev.pocketcrew.domain.port.repository.ChatRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
+import org.junit.jupiter.api.Assertions
+
 
 /**
  * Fake implementation of ChatRepository for testing.
@@ -116,11 +117,11 @@ class FakeChatRepository : ChatRepository {
     fun getCreatedChats(): List<Chat> = createdChats.toList()
 
     fun verifyChatCreated(times: Int) {
-        org.junit.jupiter.api.Assertions.assertEquals(times, createdChats.size)
+        Assertions.assertEquals(times, createdChats.size)
     }
 
     fun verifyChatName(expectedName: String) {
-        org.junit.jupiter.api.Assertions.assertTrue(
+        Assertions.assertTrue(
             createdChats.any { it.name == expectedName },
             "No chat was created with name: $expectedName"
         )

--- a/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/domain/usecase/FakeMessageRepository.kt
+++ b/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/domain/usecase/FakeMessageRepository.kt
@@ -1,8 +1,9 @@
 package com.browntowndev.pocketcrew.domain.usecase
-
 import com.browntowndev.pocketcrew.domain.model.chat.Message
 import com.browntowndev.pocketcrew.domain.model.chat.Role
 import com.browntowndev.pocketcrew.domain.port.repository.MessageRepository
+import org.junit.jupiter.api.Assertions
+
 
 /**
  * Fake implementation of MessageRepository for testing.
@@ -40,11 +41,11 @@ class FakeMessageRepository : MessageRepository {
     fun getSavedMessages(): List<Message> = savedMessages.toList()
 
     fun verifySaveMessageCalled(times: Int) {
-        org.junit.jupiter.api.Assertions.assertEquals(times, savedMessages.size)
+        Assertions.assertEquals(times, savedMessages.size)
     }
 
     fun verifyMessageSaved(message: Message) {
-        org.junit.jupiter.api.Assertions.assertTrue(
+        Assertions.assertTrue(
             savedMessages.any { it.id == message.id && it.content == message.content && it.role == message.role },
             "Message was not saved: $message"
         )

--- a/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/domain/usecase/FakeTransactionProvider.kt
+++ b/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/domain/usecase/FakeTransactionProvider.kt
@@ -1,6 +1,7 @@
 package com.browntowndev.pocketcrew.domain.usecase
-
 import com.browntowndev.pocketcrew.domain.port.repository.TransactionProvider
+import org.junit.jupiter.api.Assertions
+
 
 /**
  * Fake implementation of TransactionProvider for testing.
@@ -22,7 +23,7 @@ class FakeTransactionProvider : TransactionProvider {
     fun getTransactionCount(): Int = transactionCount
 
     fun verifyTransactionCalled(times: Int) {
-        org.junit.jupiter.api.Assertions.assertEquals(times, transactionCount)
+        Assertions.assertEquals(times, transactionCount)
     }
 
     fun setShouldThrowInTransaction(shouldThrow: Boolean) {

--- a/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/domain/usecase/chat/EdgeCaseTests.kt
+++ b/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/domain/usecase/chat/EdgeCaseTests.kt
@@ -15,19 +15,18 @@
  */
 
 package com.browntowndev.pocketcrew.domain.usecase.chat
-
 import com.browntowndev.pocketcrew.domain.model.MessageState
-import com.browntowndev.pocketcrew.domain.usecase.FakeInferenceFactory
 import com.browntowndev.pocketcrew.domain.model.chat.Mode
+import com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration
 import com.browntowndev.pocketcrew.domain.model.inference.ModelType
 import com.browntowndev.pocketcrew.domain.port.inference.InferenceEvent
 import com.browntowndev.pocketcrew.domain.port.inference.LlmInferencePort
 import com.browntowndev.pocketcrew.domain.port.inference.LoggingPort
 import com.browntowndev.pocketcrew.domain.port.inference.PipelineExecutorPort
-import kotlinx.coroutines.flow.flow
 import com.browntowndev.pocketcrew.domain.port.repository.ChatRepository
 import com.browntowndev.pocketcrew.domain.port.repository.MessageRepository
 import com.browntowndev.pocketcrew.domain.port.repository.ModelRegistryPort
+import com.browntowndev.pocketcrew.domain.usecase.FakeInferenceFactory
 import com.browntowndev.pocketcrew.domain.usecase.inference.InferenceLockManager
 import com.browntowndev.pocketcrew.domain.usecase.inference.InferenceLockManagerImpl
 import com.browntowndev.pocketcrew.domain.usecase.inference.InferenceType
@@ -35,14 +34,16 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
 
 /**
  * Edge case tests for GenerateChatResponseUseCase.
@@ -102,7 +103,7 @@ class EdgeCaseTests {
     @Test
     fun `empty thinking is handled correctly`() = runTest {
         // Given - response with no thinking
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -139,7 +140,7 @@ class EdgeCaseTests {
     @Test
     fun `long responses are handled correctly`() = runTest {
         // Given - response with many partial responses
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         val partialResponses = (1..100).map { i ->
@@ -176,7 +177,7 @@ class EdgeCaseTests {
     @Test
     fun `lock is acquired and released correctly`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -233,7 +234,7 @@ class EdgeCaseTests {
     @Test
     fun `safety blocked returns proper message`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(

--- a/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/domain/usecase/chat/GenerateChatResponseUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/domain/usecase/chat/GenerateChatResponseUseCaseTest.kt
@@ -15,10 +15,9 @@
  */
 
 package com.browntowndev.pocketcrew.domain.usecase.chat
-
 import com.browntowndev.pocketcrew.domain.model.MessageState
-import com.browntowndev.pocketcrew.domain.usecase.FakeInferenceFactory
 import com.browntowndev.pocketcrew.domain.model.chat.Mode
+import com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration
 import com.browntowndev.pocketcrew.domain.model.inference.ModelType
 import com.browntowndev.pocketcrew.domain.model.inference.PipelineStep
 import com.browntowndev.pocketcrew.domain.port.inference.InferenceEvent
@@ -28,6 +27,8 @@ import com.browntowndev.pocketcrew.domain.port.inference.PipelineExecutorPort
 import com.browntowndev.pocketcrew.domain.port.repository.ChatRepository
 import com.browntowndev.pocketcrew.domain.port.repository.MessageRepository
 import com.browntowndev.pocketcrew.domain.port.repository.ModelRegistryPort
+import com.browntowndev.pocketcrew.domain.usecase.FakeInferenceFactory
+import com.browntowndev.pocketcrew.domain.usecase.FakePipelineExecutor
 import com.browntowndev.pocketcrew.domain.usecase.inference.InferenceLockManager
 import com.browntowndev.pocketcrew.domain.usecase.inference.InferenceLockManagerImpl
 import com.browntowndev.pocketcrew.domain.usecase.inference.InferenceType
@@ -36,15 +37,15 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import com.browntowndev.pocketcrew.domain.usecase.FakePipelineExecutor
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
 
 /**
  * Tests for GenerateChatResponseUseCase - Real-Time Flow Architecture.
@@ -104,7 +105,7 @@ class GenerateChatResponseUseCaseTest {
     @Test
     fun `FAST mode emits AccumulatedMessages with accumulated content`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -146,7 +147,7 @@ class GenerateChatResponseUseCaseTest {
     @Test
     fun `content is accumulated across multiple PartialResponse events`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -186,7 +187,7 @@ class GenerateChatResponseUseCaseTest {
     @Test
     fun `thinking content is accumulated across multiple Thinking events`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -223,7 +224,7 @@ class GenerateChatResponseUseCaseTest {
     @Test
     fun `isComplete is set to true when inference finishes`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -258,7 +259,7 @@ class GenerateChatResponseUseCaseTest {
     @Test
     fun `inference completes without error`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -288,7 +289,7 @@ class GenerateChatResponseUseCaseTest {
     @Test
     fun `error in inference is handled gracefully`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -323,11 +324,11 @@ class GenerateChatResponseUseCaseTest {
     @Test
     fun `Processing event sets currentState to PROCESSING`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.DRAFT_ONE) } returns mockConfig
 
         // Mock pipeline executor to emit Processing event
-        val fakePipelineExecutor = com.browntowndev.pocketcrew.domain.usecase.FakePipelineExecutor()
+        val fakePipelineExecutor = FakePipelineExecutor()
         fakePipelineExecutor.addProcessingEvent(ModelType.DRAFT_ONE)
         
         // Create new use case with fake executor
@@ -370,7 +371,7 @@ class GenerateChatResponseUseCaseTest {
     @Test
     fun `Processing event sets pipelineStep correctly for each model type`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(any()) } returns mockConfig
 
         val testCases = listOf(
@@ -382,7 +383,7 @@ class GenerateChatResponseUseCaseTest {
 
         for ((modelType, expectedPipelineStep) in testCases) {
             // Given - fresh fake executor for each test case
-            val fakePipelineExecutor = com.browntowndev.pocketcrew.domain.usecase.FakePipelineExecutor()
+            val fakePipelineExecutor = FakePipelineExecutor()
             fakePipelineExecutor.addProcessingEvent(modelType)
             
             val expectedMessageId = if (modelType == ModelType.DRAFT_ONE) 2L else 3L
@@ -428,13 +429,13 @@ class GenerateChatResponseUseCaseTest {
     @Test
     fun `Processing event creates new message for DRAFT_TWO in CREW mode`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(any()) } returns mockConfig
 
         // Mock createAssistantMessage to return specific IDs
         coEvery { chatRepository.createAssistantMessage(any(), any(), any(), any()) } returns 3L
 
-        val fakePipelineExecutor = com.browntowndev.pocketcrew.domain.usecase.FakePipelineExecutor()
+        val fakePipelineExecutor = FakePipelineExecutor()
         fakePipelineExecutor.addProcessingEvent(ModelType.DRAFT_TWO)
         
         val useCase = GenerateChatResponseUseCase(
@@ -477,13 +478,13 @@ class GenerateChatResponseUseCaseTest {
     @Test
     fun `Processing event creates new message for SYNTHESIS in CREW mode`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(any()) } returns mockConfig
 
         // Mock createAssistantMessage to return specific IDs
         coEvery { chatRepository.createAssistantMessage(any(), any(), any(), any()) } returns 4L
 
-        val fakePipelineExecutor = com.browntowndev.pocketcrew.domain.usecase.FakePipelineExecutor()
+        val fakePipelineExecutor = FakePipelineExecutor()
         fakePipelineExecutor.addProcessingEvent(ModelType.MAIN)
         
         val useCase = GenerateChatResponseUseCase(
@@ -526,13 +527,13 @@ class GenerateChatResponseUseCaseTest {
     @Test
     fun `Processing event creates new message for FINAL in CREW mode`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(any()) } returns mockConfig
 
         // Mock createAssistantMessage to return specific IDs
         coEvery { chatRepository.createAssistantMessage(any(), any(), any(), any()) } returns 5L
 
-        val fakePipelineExecutor = com.browntowndev.pocketcrew.domain.usecase.FakePipelineExecutor()
+        val fakePipelineExecutor = FakePipelineExecutor()
         fakePipelineExecutor.addProcessingEvent(ModelType.FINAL_SYNTHESIS)
         
         val useCase = GenerateChatResponseUseCase(
@@ -575,7 +576,7 @@ class GenerateChatResponseUseCaseTest {
     @Test
     fun `complete CREW pipeline emits Processing state before each step`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(any()) } returns mockConfig
 
         // Mock createAssistantMessage to return sequential IDs
@@ -584,7 +585,7 @@ class GenerateChatResponseUseCaseTest {
             nextId++
         }
 
-        val fakePipelineExecutor = com.browntowndev.pocketcrew.domain.usecase.FakePipelineExecutor()
+        val fakePipelineExecutor = FakePipelineExecutor()
         fakePipelineExecutor.configureCompleteCrewPipeline()
 
         val useCase = GenerateChatResponseUseCase(
@@ -663,7 +664,7 @@ class GenerateChatResponseUseCaseTest {
     @Test
     fun `pipelineStep is correctly persisted for FAST mode`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(ModelType.FAST) } returns mockConfig
 
         every { fastModelService.sendPrompt(any(), any()) } returns flowOf(
@@ -700,7 +701,7 @@ class GenerateChatResponseUseCaseTest {
     @Test
     fun `pipelineStep is correctly computed from modelType for CREW mode`() = runTest {
         // Given
-        val mockConfig = mockk<com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration>()
+        val mockConfig = mockk<ModelConfiguration>()
         every { modelRegistry.getRegisteredModelSync(any()) } returns mockConfig
 
         val testCases = listOf(

--- a/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/testing/Fakes.kt
+++ b/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/testing/Fakes.kt
@@ -15,10 +15,10 @@
  */
 
 package com.browntowndev.pocketcrew.testing
-
 import com.browntowndev.pocketcrew.domain.model.config.ModelConfiguration
 import com.browntowndev.pocketcrew.domain.model.config.ModelStatus
 import com.browntowndev.pocketcrew.domain.model.download.DownloadModelsResult
+import com.browntowndev.pocketcrew.domain.model.download.DownloadProgressUpdate
 import com.browntowndev.pocketcrew.domain.model.download.DownloadState
 import com.browntowndev.pocketcrew.domain.model.download.DownloadStatus
 import com.browntowndev.pocketcrew.domain.model.download.FileProgress
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
+
 
 class FakeModelDownloadOrchestrator : ModelDownloadOrchestratorPort {
     private val _downloadState = MutableStateFlow(DownloadState(status = DownloadStatus.CHECKING))
@@ -112,7 +113,7 @@ class FakeModelDownloadOrchestrator : ModelDownloadOrchestratorPort {
         return startDownloads(modelsResult, wifiOnly)
     }
 
-    override suspend fun updateFromProgressUpdate(progressUpdate: com.browntowndev.pocketcrew.domain.model.download.DownloadProgressUpdate) {}
+    override suspend fun updateFromProgressUpdate(progressUpdate: DownloadProgressUpdate) {}
 
     override fun pauseDownloads() {
         _downloadState.value = _downloadState.value.copy(status = DownloadStatus.PAUSED)

--- a/core/domain/src/testFixtures/kotlin/com/browntowndev/pocketcrew/domain/usecase/FakeSettingsRepository.kt
+++ b/core/domain/src/testFixtures/kotlin/com/browntowndev/pocketcrew/domain/usecase/FakeSettingsRepository.kt
@@ -1,5 +1,4 @@
 package com.browntowndev.pocketcrew.domain.usecase
-
 import com.browntowndev.pocketcrew.domain.model.settings.AppTheme
 import com.browntowndev.pocketcrew.domain.model.settings.SystemPromptOption
 import com.browntowndev.pocketcrew.domain.port.repository.SettingsData
@@ -7,6 +6,8 @@ import com.browntowndev.pocketcrew.domain.port.repository.SettingsRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import org.junit.jupiter.api.Assertions
+
 
 /**
  * Fake implementation of SettingsRepository for testing.
@@ -151,6 +152,6 @@ class FakeSettingsRepository : SettingsRepository {
     }
 
     private fun assertEquals(expected: Any?, actual: Any?) {
-        org.junit.jupiter.api.Assertions.assertEquals(expected, actual)
+        Assertions.assertEquals(expected, actual)
     }
 }

--- a/core/ui/src/main/kotlin/com/browntowndev/pocketcrew/core/ui/component/markdown/StreamableMarkdownText.kt
+++ b/core/ui/src/main/kotlin/com/browntowndev/pocketcrew/core/ui/component/markdown/StreamableMarkdownText.kt
@@ -1,17 +1,18 @@
 package com.browntowndev.pocketcrew.core.ui.component.markdown
-
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import com.browntowndev.pocketcrew.core.ui.theme.darkMarkdownTheme
 import com.hrm.markdown.renderer.Markdown
+
 
 /**
  * A composable that renders markdown text with support for streaming updates.
@@ -86,7 +87,7 @@ fun SimpleMarkdownText(
     )
 }
 
-private fun parseSimpleMarkdown(text: String): androidx.compose.ui.text.AnnotatedString {
+private fun parseSimpleMarkdown(text: String): AnnotatedString {
     return buildAnnotatedString {
         var currentIndex = 0
         val processedText = text

--- a/core/ui/src/main/kotlin/com/browntowndev/pocketcrew/core/ui/error/GlobalErrorHandler.kt
+++ b/core/ui/src/main/kotlin/com/browntowndev/pocketcrew/core/ui/error/GlobalErrorHandler.kt
@@ -1,17 +1,18 @@
 package com.browntowndev.pocketcrew.core.ui.error
-
 import android.app.Application
 import android.content.ContentProvider
 import android.content.ContentValues
 import android.database.Cursor
 import android.net.Uri
+import android.util.Log
 import com.browntowndev.pocketcrew.domain.port.inference.LoggingPort
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineExceptionHandler
+
 
 /**
  * Global exception handler that catches uncaught coroutine exceptions.
@@ -40,8 +41,8 @@ class GlobalErrorHandler : CoroutineExceptionHandler {
             loggingPort.error("GlobalErrorHandler", "Uncaught coroutine exception", exception)
         } catch (e: Exception) {
             // Fallback if Hilt is not yet initialized or other issues
-            android.util.Log.e("GlobalErrorHandler", "Failed to log global exception", e)
-            android.util.Log.e("GlobalErrorHandler", "Original exception: ", exception)
+            Log.e("GlobalErrorHandler", "Failed to log global exception", e)
+            Log.e("GlobalErrorHandler", "Original exception: ", exception)
         }
     }
 }

--- a/feature/chat/src/main/kotlin/com/browntowndev/pocketcrew/feature/chat/ChatViewModel.kt
+++ b/feature/chat/src/main/kotlin/com/browntowndev/pocketcrew/feature/chat/ChatViewModel.kt
@@ -1,8 +1,8 @@
 package com.browntowndev.pocketcrew.feature.chat
-
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.browntowndev.pocketcrew.core.ui.error.ViewModelErrorHandler
 import com.browntowndev.pocketcrew.domain.model.MessageState
 import com.browntowndev.pocketcrew.domain.model.chat.Content
 import com.browntowndev.pocketcrew.domain.model.chat.Message
@@ -14,8 +14,11 @@ import com.browntowndev.pocketcrew.domain.usecase.chat.MessageSnapshot
 import com.browntowndev.pocketcrew.domain.usecase.inference.InferenceLockManager
 import com.browntowndev.pocketcrew.domain.usecase.settings.SettingsUseCases
 import com.browntowndev.pocketcrew.feature.chat.ChatModeMapper.toDomain
-import com.browntowndev.pocketcrew.core.ui.error.ViewModelErrorHandler
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
@@ -32,7 +35,7 @@ import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import javax.inject.Inject
+
 
 /**
  * ViewModel for the Chat screen.
@@ -241,8 +244,8 @@ class ChatViewModel @Inject constructor(
         // Handle 0 timestamp (not set)
         if (timestamp == 0L) return "Now"
         // Simple timestamp formatting - could be enhanced
-        val sdf = java.text.SimpleDateFormat("h:mm a", java.util.Locale.getDefault())
-        return sdf.format(java.util.Date(timestamp))
+        val sdf = SimpleDateFormat("h:mm a", Locale.getDefault())
+        return sdf.format(Date(timestamp))
     }
 
     fun onInputChange(inputText: String) {

--- a/feature/chat/src/main/kotlin/com/browntowndev/pocketcrew/feature/chat/components/MessageList.kt
+++ b/feature/chat/src/main/kotlin/com/browntowndev/pocketcrew/feature/chat/components/MessageList.kt
@@ -1,9 +1,8 @@
 package com.browntowndev.pocketcrew.feature.chat.components
-
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.ui.draw.rotate
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -11,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -30,24 +30,24 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.offset
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.browntowndev.pocketcrew.feature.chat.R
+import com.browntowndev.pocketcrew.core.ui.component.markdown.SimpleMarkdownText
+import com.browntowndev.pocketcrew.core.ui.theme.PocketCrewTheme
+import com.browntowndev.pocketcrew.domain.model.inference.PipelineStep
 import com.browntowndev.pocketcrew.feature.chat.ChatMessage
 import com.browntowndev.pocketcrew.feature.chat.ContentUi
 import com.browntowndev.pocketcrew.feature.chat.IndicatorState
-import com.browntowndev.pocketcrew.domain.model.inference.PipelineStep
 import com.browntowndev.pocketcrew.feature.chat.MessageRole
+import com.browntowndev.pocketcrew.feature.chat.R
 import com.browntowndev.pocketcrew.feature.chat.ThinkingDataUi
 import com.browntowndev.pocketcrew.feature.chat.fakeLongMessages
-import com.browntowndev.pocketcrew.core.ui.theme.PocketCrewTheme
-import com.browntowndev.pocketcrew.core.ui.component.markdown.SimpleMarkdownText
+
 
 @Composable
 fun MessageList(
@@ -154,7 +154,7 @@ private fun Indicators(modelDisplayName: String, indicatorState: IndicatorState?
                 (indicatorState is IndicatorState.Generating && indicatorState.thinkingData?.thinkingDurationSeconds == 0L)
 
         if (startTime > 0 && isThinkingActive) {
-            androidx.compose.runtime.LaunchedEffect(startTime) {
+            LaunchedEffect(startTime) {
                 while (true) {
                     elapsedSeconds = ((System.currentTimeMillis() - startTime) / 1000).toInt()
                     kotlinx.coroutines.delay(1000L)

--- a/feature/chat/src/main/kotlin/com/browntowndev/pocketcrew/feature/chat/components/ThinkingIndicator.kt
+++ b/feature/chat/src/main/kotlin/com/browntowndev/pocketcrew/feature/chat/components/ThinkingIndicator.kt
@@ -1,5 +1,4 @@
 package com.browntowndev.pocketcrew.feature.chat.components
-
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
@@ -26,10 +25,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.browntowndev.pocketcrew.core.ui.component.ShimmerText
 import kotlinx.coroutines.delay
+
 
 /**
  * Redesigned Thinking Indicator that matches the Grok-style thinking indicator.
@@ -141,7 +142,7 @@ private fun PreviewTheme(content: @Composable () -> Unit) {
     }
 }
 
-@androidx.compose.ui.tooling.preview.Preview(showBackground = true, backgroundColor = 0xFF121212)
+@Preview(showBackground = true, backgroundColor = 0xFF121212)
 @Composable
 fun ThinkingIndicator_EmptyPreview() {
     PreviewTheme {
@@ -153,7 +154,7 @@ fun ThinkingIndicator_EmptyPreview() {
     }
 }
 
-@androidx.compose.ui.tooling.preview.Preview(showBackground = true, backgroundColor = 0xFF121212)
+@Preview(showBackground = true, backgroundColor = 0xFF121212)
 @Composable
 fun ThinkingIndicator_WithContentPreview() {
     PreviewTheme {

--- a/feature/chat/src/test/kotlin/com/browntowndev/pocketcrew/feature/chat/ChatViewModelTest.kt
+++ b/feature/chat/src/test/kotlin/com/browntowndev/pocketcrew/feature/chat/ChatViewModelTest.kt
@@ -15,29 +15,30 @@
  */
 
 package com.browntowndev.pocketcrew.feature.chat
-
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.browntowndev.pocketcrew.core.testing.MainDispatcherRule
+import com.browntowndev.pocketcrew.core.ui.error.ViewModelErrorHandler
 import com.browntowndev.pocketcrew.domain.model.MessageState
 import com.browntowndev.pocketcrew.domain.model.chat.Content
 import com.browntowndev.pocketcrew.domain.model.chat.Message
 import com.browntowndev.pocketcrew.domain.model.chat.Role
+import com.browntowndev.pocketcrew.domain.model.inference.PipelineStep
 import com.browntowndev.pocketcrew.domain.usecase.chat.ChatUseCases
 import com.browntowndev.pocketcrew.domain.usecase.chat.GetModelDisplayNameUseCase
 import com.browntowndev.pocketcrew.domain.usecase.inference.InferenceLockManager
 import com.browntowndev.pocketcrew.domain.usecase.settings.SettingsUseCases
-import com.browntowndev.pocketcrew.core.ui.error.ViewModelErrorHandler
 import io.mockk.*
+import java.io.IOException
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.test.runTest
-
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import com.browntowndev.pocketcrew.domain.model.inference.PipelineStep
+
+
 
 /**
  * Tests for ChatViewModel's mapping logic.
@@ -90,7 +91,7 @@ class ChatViewModelTest {
         val input = "Hello"
         chatViewModel.onInputChange(input)
         
-        val exception = java.io.IOException("Network error")
+        val exception = IOException("Network error")
         coEvery { chatUseCases.processPrompt(any()) } throws exception
         
         // When

--- a/feature/download/src/main/kotlin/com/browntowndev/pocketcrew/feature/download/ModelDownloadScreen.kt
+++ b/feature/download/src/main/kotlin/com/browntowndev/pocketcrew/feature/download/ModelDownloadScreen.kt
@@ -1,8 +1,8 @@
 package com.browntowndev.pocketcrew.feature.download
-
 import android.Manifest
 import android.app.Activity
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.pm.PackageManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -36,6 +36,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -64,18 +65,19 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.browntowndev.pocketcrew.core.data.util.formatBytes
+import com.browntowndev.pocketcrew.core.ui.theme.PocketCrewTheme
+import com.browntowndev.pocketcrew.core.ui.util.FeatureFlags
+import com.browntowndev.pocketcrew.domain.model.download.DownloadModelsResult
 import com.browntowndev.pocketcrew.domain.model.download.DownloadStatus
 import com.browntowndev.pocketcrew.domain.model.download.FileStatus
 import com.browntowndev.pocketcrew.domain.model.inference.ModelFile
-import com.browntowndev.pocketcrew.domain.model.download.DownloadModelsResult
 import com.browntowndev.pocketcrew.feature.download.DownloadViewModel.FileProgressUiModel
-import com.browntowndev.pocketcrew.core.ui.theme.PocketCrewTheme
-import com.browntowndev.pocketcrew.core.ui.util.FeatureFlags
-import com.browntowndev.pocketcrew.core.data.util.formatBytes
+
 
 /**
  * Full-screen model download status page.
@@ -265,7 +267,7 @@ fun ModelDownloadScreen(
  */
 private fun Context.findActivity(): Activity? {
     var context = this
-    while (context is android.content.ContextWrapper) {
+    while (context is ContextWrapper) {
         if (context is Activity) {
             return context
         }
@@ -1161,7 +1163,7 @@ private fun PreviewBackgroundNotice() {
         ) {
             Text("With Permission", style = MaterialTheme.typography.titleMedium)
             BackgroundNotice(hasPermission = true)
-            androidx.compose.material3.HorizontalDivider()
+            HorizontalDivider()
             Text("Without Permission", style = MaterialTheme.typography.titleMedium)
             BackgroundNotice(hasPermission = false)
         }

--- a/feature/history/src/main/kotlin/com/browntowndev/pocketcrew/feature/history/HistoryViewModel.kt
+++ b/feature/history/src/main/kotlin/com/browntowndev/pocketcrew/feature/history/HistoryViewModel.kt
@@ -1,15 +1,21 @@
 package com.browntowndev.pocketcrew.feature.history
-
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.browntowndev.pocketcrew.core.ui.error.ViewModelErrorHandler
 import com.browntowndev.pocketcrew.domain.model.chat.Chat
+import com.browntowndev.pocketcrew.domain.model.settings.AppTheme
+import com.browntowndev.pocketcrew.domain.model.settings.SystemPromptOption
+import com.browntowndev.pocketcrew.domain.port.repository.SettingsData
 import com.browntowndev.pocketcrew.domain.usecase.chat.DeleteChatUseCase
 import com.browntowndev.pocketcrew.domain.usecase.chat.GetAllChatsUseCase
 import com.browntowndev.pocketcrew.domain.usecase.chat.RenameChatUseCase
+import com.browntowndev.pocketcrew.domain.usecase.chat.SearchChatsUseCase
 import com.browntowndev.pocketcrew.domain.usecase.chat.TogglePinChatUseCase
 import com.browntowndev.pocketcrew.domain.usecase.settings.GetSettingsUseCase
-import com.browntowndev.pocketcrew.core.ui.error.ViewModelErrorHandler
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -17,15 +23,14 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import javax.inject.Inject
-import com.browntowndev.pocketcrew.domain.usecase.chat.SearchChatsUseCase
+
 
 /**
  * ViewModel for the History screen.
@@ -58,7 +63,7 @@ class HistoryViewModel @Inject constructor(
         val other: List<HistoryChat>
     )
 
-    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class, kotlinx.coroutines.FlowPreview::class)
+    @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
     val uiState: StateFlow<HistoryUiState> = combine(
         _searchQuery.debounce(300L).flatMapLatest { query ->
             if (query.isBlank()) {
@@ -69,12 +74,12 @@ class HistoryViewModel @Inject constructor(
         },
         getSettingsUseCase().catch { 
             emit(
-                com.browntowndev.pocketcrew.domain.port.repository.SettingsData(
-                    theme = com.browntowndev.pocketcrew.domain.model.settings.AppTheme.SYSTEM,
+                SettingsData(
+                    theme = AppTheme.SYSTEM,
                     hapticPress = true,
                     hapticResponse = true,
                     customizationEnabled = false,
-                    selectedPromptOption = com.browntowndev.pocketcrew.domain.model.settings.SystemPromptOption.CONCISE,
+                    selectedPromptOption = SystemPromptOption.CONCISE,
                     customPromptText = "",
                     allowMemories = false
                 )

--- a/feature/history/src/test/kotlin/com/browntowndev/pocketcrew/feature/history/HistoryViewModelTest.kt
+++ b/feature/history/src/test/kotlin/com/browntowndev/pocketcrew/feature/history/HistoryViewModelTest.kt
@@ -1,20 +1,23 @@
 package com.browntowndev.pocketcrew.feature.history
-
+import com.browntowndev.pocketcrew.core.testing.MainDispatcherRule
+import com.browntowndev.pocketcrew.core.ui.error.ViewModelErrorHandler
+import com.browntowndev.pocketcrew.domain.model.chat.Chat
 import com.browntowndev.pocketcrew.domain.model.settings.AppTheme
 import com.browntowndev.pocketcrew.domain.model.settings.SystemPromptOption
 import com.browntowndev.pocketcrew.domain.port.repository.SettingsData
-import com.browntowndev.pocketcrew.domain.model.chat.Chat
 import com.browntowndev.pocketcrew.domain.usecase.chat.DeleteChatUseCase
 import com.browntowndev.pocketcrew.domain.usecase.chat.GetAllChatsUseCase
 import com.browntowndev.pocketcrew.domain.usecase.chat.RenameChatUseCase
+import com.browntowndev.pocketcrew.domain.usecase.chat.SearchChatsUseCase
 import com.browntowndev.pocketcrew.domain.usecase.chat.TogglePinChatUseCase
 import com.browntowndev.pocketcrew.domain.usecase.settings.GetSettingsUseCase
 import com.browntowndev.pocketcrew.domain.usecase.settings.SettingsUseCases
-import com.browntowndev.pocketcrew.core.testing.MainDispatcherRule
-import com.browntowndev.pocketcrew.core.ui.error.ViewModelErrorHandler
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import java.util.Calendar
+import java.util.Date
+import java.util.TimeZone
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
@@ -29,9 +32,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
-import java.util.Calendar
-import java.util.Date
-import java.util.TimeZone
+
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class HistoryViewModelTest {
@@ -43,7 +44,7 @@ class HistoryViewModelTest {
     val mainDispatcherRule = MainDispatcherRule(testDispatcher)
 
     private lateinit var mockGetAllChatsUseCase: GetAllChatsUseCase
-    private lateinit var mockSearchChatsUseCase: com.browntowndev.pocketcrew.domain.usecase.chat.SearchChatsUseCase
+    private lateinit var mockSearchChatsUseCase: SearchChatsUseCase
     private lateinit var mockDeleteChatUseCase: DeleteChatUseCase
     private lateinit var mockRenameChatUseCase: RenameChatUseCase
     private lateinit var mockTogglePinChatUseCase: TogglePinChatUseCase

--- a/feature/inference/src/test/kotlin/com/browntowndev/pocketcrew/feature/inference/ConversationManagerImplTest.kt
+++ b/feature/inference/src/test/kotlin/com/browntowndev/pocketcrew/feature/inference/ConversationManagerImplTest.kt
@@ -1,9 +1,10 @@
 package com.browntowndev.pocketcrew.feature.inference
-
 import android.util.Log
 import com.browntowndev.pocketcrew.domain.model.chat.ChatMessage
 import com.browntowndev.pocketcrew.domain.model.chat.Role
 import com.browntowndev.pocketcrew.domain.port.inference.ConversationPort
+import com.google.ai.edge.litertlm.Content
+import com.google.ai.edge.litertlm.Conversation
 import com.google.ai.edge.litertlm.ConversationConfig
 import com.google.ai.edge.litertlm.Engine
 import io.mockk.MockKAnnotations
@@ -14,16 +15,17 @@ import io.mockk.slot
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
 
 class ConversationManagerImplTest {
 
     private lateinit var mockEngine: Engine
-    private lateinit var mockConversation: com.google.ai.edge.litertlm.Conversation
+    private lateinit var mockConversation: Conversation
 
     @BeforeEach
     fun setup() {
@@ -171,9 +173,9 @@ class ConversationManagerImplTest {
         assertEquals(2, initialMessages.size)
         // Verify mapping (role and content)
         assertEquals("user", initialMessages[0].role.name.lowercase())
-        assertEquals("Hello, what's up?", initialMessages[0].contents.contents.filterIsInstance<com.google.ai.edge.litertlm.Content.Text>().joinToString("") { it.text })
+        assertEquals("Hello, what's up?", initialMessages[0].contents.contents.filterIsInstance<Content.Text>().joinToString("") { it.text })
         assertEquals("model", initialMessages[1].role.name.lowercase())
-        assertEquals("Not much, how are you?", initialMessages[1].contents.contents.filterIsInstance<com.google.ai.edge.litertlm.Content.Text>().joinToString("") { it.text })
+        assertEquals("Not much, how are you?", initialMessages[1].contents.contents.filterIsInstance<Content.Text>().joinToString("") { it.text })
     }
 
     @Test

--- a/feature/settings/src/main/kotlin/com/browntowndev/pocketcrew/feature/settings/SettingsRoute.kt
+++ b/feature/settings/src/main/kotlin/com/browntowndev/pocketcrew/feature/settings/SettingsRoute.kt
@@ -1,5 +1,4 @@
 package com.browntowndev.pocketcrew.feature.settings
-
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.runtime.Composable
@@ -7,6 +6,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.browntowndev.pocketcrew.domain.model.inference.ModelType
+
 
 @Composable
 fun SettingsRoute(
@@ -14,7 +15,7 @@ fun SettingsRoute(
     onShowSnackbar: (message: String, actionLabel: String?) -> Unit,
     onNavigateToModelDownload: () -> Unit,
     onNavigateToByokConfigure: () -> Unit,
-    onNavigateToModelConfigure: (com.browntowndev.pocketcrew.domain.model.inference.ModelType) -> Unit,
+    onNavigateToModelConfigure: (ModelType) -> Unit,
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()

--- a/feature/settings/src/main/kotlin/com/browntowndev/pocketcrew/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/com/browntowndev/pocketcrew/feature/settings/SettingsScreen.kt
@@ -1,10 +1,4 @@
 package com.browntowndev.pocketcrew.feature.settings
-
-import com.browntowndev.pocketcrew.core.ui.theme.PocketCrewTheme
-import com.browntowndev.pocketcrew.domain.model.inference.ModelType
-import com.browntowndev.pocketcrew.domain.model.settings.AppTheme
-import com.browntowndev.pocketcrew.domain.model.settings.SystemPromptOption
-
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -50,6 +44,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
@@ -60,7 +55,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
-import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
@@ -72,12 +66,20 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.launch
+import com.browntowndev.pocketcrew.core.ui.theme.PocketCrewTheme
+import com.browntowndev.pocketcrew.domain.model.inference.ModelSource
+import com.browntowndev.pocketcrew.domain.model.inference.ModelType
+import com.browntowndev.pocketcrew.domain.model.settings.AppTheme
+import com.browntowndev.pocketcrew.domain.model.settings.SystemPromptOption
 import java.util.Locale
+import kotlinx.coroutines.launch
+
+
 
 /**
  * Returns a user-friendly display name for a ModelType enum value.
@@ -117,15 +119,15 @@ fun SettingsScreen(
     onFeedbackTextChange: (String) -> Unit,
     onSubmitFeedback: () -> Unit,
     onNavigateToModelDownload: () -> Unit,
-    onNavigateToModelConfigure: (com.browntowndev.pocketcrew.domain.model.inference.ModelType) -> Unit,
+    onNavigateToModelConfigure: (ModelType) -> Unit,
     // Model Configuration
     onShowModelConfigSheet: (Boolean) -> Unit,
-    onSelectModelType: (com.browntowndev.pocketcrew.domain.model.inference.ModelType) -> Unit,
+    onSelectModelType: (ModelType) -> Unit,
     // BYOK
     onShowByokSheet: (Boolean) -> Unit,
     onNavigateToByokConfigure: () -> Unit,
     onSelectApiModel: (Long?) -> Unit,
-    onSetDefaultModel: (com.browntowndev.pocketcrew.domain.model.inference.ModelType, com.browntowndev.pocketcrew.domain.model.inference.ModelSource, Long?) -> Unit,
+    onSetDefaultModel: (ModelType, ModelSource, Long?) -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -396,7 +398,7 @@ fun SettingsIcon(icon: Any) {
             modifier = Modifier.size(24.dp),
             tint = MaterialTheme.colorScheme.onSurfaceVariant
         )
-        is androidx.compose.ui.graphics.painter.Painter -> Icon(
+        is Painter -> Icon(
             painter = icon,
             contentDescription = null,
             modifier = Modifier.size(24.dp),
@@ -708,8 +710,8 @@ fun FeedbackBottomSheet(
 fun ModelConfigurationBottomSheet(
     uiState: SettingsUiState,
     onDismiss: () -> Unit,
-    onSelectModelType: (com.browntowndev.pocketcrew.domain.model.inference.ModelType) -> Unit,
-    onNavigateToModelConfigure: (com.browntowndev.pocketcrew.domain.model.inference.ModelType) -> Unit,
+    onSelectModelType: (ModelType) -> Unit,
+    onNavigateToModelConfigure: (ModelType) -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val scope = rememberCoroutineScope()
@@ -733,7 +735,7 @@ fun ModelConfigurationBottomSheet(
             Spacer(modifier = Modifier.height(16.dp))
 
             LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                val types = com.browntowndev.pocketcrew.domain.model.inference.ModelType.entries
+                val types = ModelType.entries
                 items(types) { modelType ->
                     val assignment = uiState.defaultAssignments.find { it.modelType == modelType }
                     val nameStr = assignment?.currentModelName ?: "Unknown"

--- a/feature/settings/src/main/kotlin/com/browntowndev/pocketcrew/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/browntowndev/pocketcrew/feature/settings/SettingsViewModel.kt
@@ -1,40 +1,41 @@
 package com.browntowndev.pocketcrew.feature.settings
-
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.browntowndev.pocketcrew.domain.model.settings.AppTheme
-import com.browntowndev.pocketcrew.domain.model.config.ModelConfigurationUi
-import com.browntowndev.pocketcrew.domain.model.inference.ModelType
-import com.browntowndev.pocketcrew.domain.model.settings.SystemPromptOption
-import com.browntowndev.pocketcrew.domain.usecase.modelconfig.GetModelConfigurationsUseCase
-import com.browntowndev.pocketcrew.domain.usecase.modelconfig.UpdateModelConfigurationUseCase
-import com.browntowndev.pocketcrew.domain.usecase.settings.GetSettingsUseCase
-import com.browntowndev.pocketcrew.domain.usecase.settings.UpdateAllowMemoriesUseCase
-import com.browntowndev.pocketcrew.domain.usecase.settings.UpdateCustomizationEnabledUseCase
-import com.browntowndev.pocketcrew.domain.usecase.settings.UpdateCustomPromptTextUseCase
-import com.browntowndev.pocketcrew.domain.usecase.settings.UpdateHapticPressUseCase
-import com.browntowndev.pocketcrew.domain.usecase.settings.UpdateHapticResponseUseCase
-import com.browntowndev.pocketcrew.domain.usecase.settings.UpdateSelectedPromptOptionUseCase
+import com.browntowndev.pocketcrew.core.ui.error.ViewModelErrorHandler
 import com.browntowndev.pocketcrew.domain.model.config.ApiModelConfig
+import com.browntowndev.pocketcrew.domain.model.config.ModelConfigurationUi
 import com.browntowndev.pocketcrew.domain.model.inference.ApiProvider
 import com.browntowndev.pocketcrew.domain.model.inference.ModelSource
+import com.browntowndev.pocketcrew.domain.model.inference.ModelType
+import com.browntowndev.pocketcrew.domain.model.settings.AppTheme
+import com.browntowndev.pocketcrew.domain.model.settings.SystemPromptOption
 import com.browntowndev.pocketcrew.domain.usecase.byok.DeleteApiModelUseCase
 import com.browntowndev.pocketcrew.domain.usecase.byok.GetApiModelsUseCase
 import com.browntowndev.pocketcrew.domain.usecase.byok.GetDefaultModelsUseCase
 import com.browntowndev.pocketcrew.domain.usecase.byok.SaveApiModelUseCase
 import com.browntowndev.pocketcrew.domain.usecase.byok.SetDefaultModelUseCase
+import com.browntowndev.pocketcrew.domain.usecase.modelconfig.GetModelConfigurationsUseCase
+import com.browntowndev.pocketcrew.domain.usecase.modelconfig.UpdateModelConfigurationUseCase
+import com.browntowndev.pocketcrew.domain.usecase.settings.GetSettingsUseCase
+import com.browntowndev.pocketcrew.domain.usecase.settings.UpdateAllowMemoriesUseCase
+import com.browntowndev.pocketcrew.domain.usecase.settings.UpdateCustomPromptTextUseCase
+import com.browntowndev.pocketcrew.domain.usecase.settings.UpdateCustomizationEnabledUseCase
+import com.browntowndev.pocketcrew.domain.usecase.settings.UpdateHapticPressUseCase
+import com.browntowndev.pocketcrew.domain.usecase.settings.UpdateHapticResponseUseCase
+import com.browntowndev.pocketcrew.domain.usecase.settings.UpdateSelectedPromptOptionUseCase
 import com.browntowndev.pocketcrew.domain.usecase.settings.UpdateThemeUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import javax.inject.Inject
+
 
 /**
  * UI-only transient state that doesn't need persistence.
@@ -77,7 +78,7 @@ class SettingsViewModel @Inject constructor(
     private val deleteApiModelUseCase: DeleteApiModelUseCase,
     private val getDefaultModelsUseCase: GetDefaultModelsUseCase,
     private val setDefaultModelUseCase: SetDefaultModelUseCase,
-    private val errorHandler: com.browntowndev.pocketcrew.core.ui.error.ViewModelErrorHandler
+    private val errorHandler: ViewModelErrorHandler
 ) : ViewModel() {
 
     companion object {


### PR DESCRIPTION
Replaced Fully Qualified Names (FQNs) with simple names and corresponding imports across the repository.
Ensured that all imports are alphabetized and there are no duplicates.
Exempted FQNs when there is a naming conflict (collision).
Did not modify third-party dependency code in build/, bin/, or generated/ directories.

---
*PR created automatically by Jules for task [7538324599559077150](https://jules.google.com/task/7538324599559077150) started by @sean-brown-dev*