### PR TITLE
⚡ Bolt: [performance improvement] Cache O(N) list computations inside `remember`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-12 - Missing remember in Jetpack Compose
+**Learning:** Found an un-remembered list computation (`messages.any { ... }`) inside `MessageList.kt` which caused it to be re-evaluated on every single recomposition of the message list. This can become a performance bottleneck when the list of messages grows, especially during message generation when recomposition happens frequently.
+**Action:** Always wrap derived state computations or heavy collection operations in `remember` (e.g. `remember(messages) { messages.any { ... } }`) in Jetpack Compose to prevent unnecessary work on recomposition.

--- a/feature/chat/src/main/kotlin/com/browntowndev/pocketcrew/feature/chat/components/MessageList.kt
+++ b/feature/chat/src/main/kotlin/com/browntowndev/pocketcrew/feature/chat/components/MessageList.kt
@@ -56,7 +56,8 @@ fun MessageList(
     isPreview: Boolean = false,
 ) {
     val listState = rememberLazyListState()
-    val hasActiveIndicator = messages.any { it.indicatorState != null }
+    // Bolt Optimization: Cache the result of this O(N) operation to avoid recalculating on every recomposition
+    val hasActiveIndicator = remember(messages) { messages.any { it.indicatorState != null } }
 
     // Auto-scroll to bottom (index 0 in reverseLayout) when messages are added
     LaunchedEffect(messages.size) {

--- a/feature/history/src/main/kotlin/com/browntowndev/pocketcrew/feature/history/HistoryScreen.kt
+++ b/feature/history/src/main/kotlin/com/browntowndev/pocketcrew/feature/history/HistoryScreen.kt
@@ -90,11 +90,14 @@ fun HistoryScreen(
     val sheetState = rememberModalBottomSheetState()
 
     val colorScheme = MaterialTheme.colorScheme
-    val shimmerColors = if (uiState.isLoading) {
-        val base = remember(colorScheme) { colorScheme.onSurface.copy(alpha = 0.05f) }
-        val highlight = remember(colorScheme) { colorScheme.onSurface.copy(alpha = 0.15f) }
-        base to highlight
-    } else null
+    // Bolt Optimization: Group conditional remember into a single block with keys to ensure proper positional memoization
+    val shimmerColors = remember(colorScheme, uiState.isLoading) {
+        if (uiState.isLoading) {
+            val base = colorScheme.onSurface.copy(alpha = 0.05f)
+            val highlight = colorScheme.onSurface.copy(alpha = 0.15f)
+            base to highlight
+        } else null
+    }
 
     val shimmerProgress = if (uiState.isLoading) {
         val infiniteTransition = rememberInfiniteTransition(label = "shimmer")


### PR DESCRIPTION
💡 What: Wrapped `messages.any { it.indicatorState != null }` inside a `remember(messages)` block in `MessageList.kt` and consolidated a conditional `remember` block in `HistoryScreen.kt`. Added explanatory comments to the code and updated the `.jules/bolt.md` performance journal.
🎯 Why: In Jetpack Compose, computing derived state directly inside a Composable causes it to be re-evaluated on every recomposition. In `MessageList.kt`, the O(N) list iteration would happen frequently (e.g. while AI messages are streaming character by character).
📊 Impact: Reduces unnecessary CPU cycles during high-frequency recomposition events in the chat UI.
🔬 Measurement: Verify by running the chat UI with streaming responses; the `messages.any` computation will only run when the `messages` list reference actually changes.

---
*PR created automatically by Jules for task [17022392093354743514](https://jules.google.com/task/17022392093354743514) started by @sean-brown-dev*