### PR TITLE
🧪 Add tests for UpdateCustomizationEnabledUseCase

### DIFF
--- a/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/domain/usecase/settings/UpdateCustomizationEnabledUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/domain/usecase/settings/UpdateCustomizationEnabledUseCaseTest.kt
@@ -1,0 +1,47 @@
+package com.browntowndev.pocketcrew.domain.usecase.settings
+
+import com.browntowndev.pocketcrew.domain.port.repository.SettingsRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class UpdateCustomizationEnabledUseCaseTest {
+
+    private lateinit var settingsRepository: SettingsRepository
+    private lateinit var updateCustomizationEnabledUseCase: UpdateCustomizationEnabledUseCase
+
+    @BeforeEach
+    fun setUp() {
+        settingsRepository = mockk()
+        updateCustomizationEnabledUseCase = UpdateCustomizationEnabledUseCase(settingsRepository)
+    }
+
+    @Test
+    fun `invoke with true calls updateCustomizationEnabled with true`() = runTest {
+        // Given
+        val enabled = true
+        coEvery { settingsRepository.updateCustomizationEnabled(any()) } returns Unit
+
+        // When
+        updateCustomizationEnabledUseCase(enabled)
+
+        // Then
+        coVerify(exactly = 1) { settingsRepository.updateCustomizationEnabled(enabled) }
+    }
+
+    @Test
+    fun `invoke with false calls updateCustomizationEnabled with false`() = runTest {
+        // Given
+        val enabled = false
+        coEvery { settingsRepository.updateCustomizationEnabled(any()) } returns Unit
+
+        // When
+        updateCustomizationEnabledUseCase(enabled)
+
+        // Then
+        coVerify(exactly = 1) { settingsRepository.updateCustomizationEnabled(enabled) }
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR introduces the missing test suite for `UpdateCustomizationEnabledUseCase.kt` inside the `core/domain` module.

📊 **Coverage:** What scenarios are now tested
- Tested invoking the use case with `true` to ensure it properly delegates the `true` argument to `settingsRepository.updateCustomizationEnabled(true)`.
- Tested invoking the use case with `false` to ensure it properly delegates the `false` argument to `settingsRepository.updateCustomizationEnabled(false)`.
- Ensures the `suspend` invocation matches the domain port appropriately without any unexpected behaviors.

✨ **Result:** The improvement in test coverage
The code base now has guaranteed determinism for `UpdateCustomizationEnabledUseCase`. Any subsequent modifications or regressions relating to customization enabling state delegation will be instantly identified by the test failures.

---
*PR created automatically by Jules for task [5918358649453089480](https://jules.google.com/task/5918358649453089480) started by @sean-brown-dev*