### PR TITLE
chore: Remove stale FIX comment from WorkProgressParser

### DIFF
--- a/core/data/src/main/kotlin/com/browntowndev/pocketcrew/core/data/download/WorkProgressParser.kt
+++ b/core/data/src/main/kotlin/com/browntowndev/pocketcrew/core/data/download/WorkProgressParser.kt
@@ -176,7 +176,6 @@ class WorkProgressParser @Inject constructor(
             val status = FileStatus.valueOf(parts[3])
             val speedMBs = parts[4].toDoubleOrNull()?.coerceAtLeast(0.0)
 
-            // FIX: Safely parse modelTypes, handle empty string
             val modelTypesStr = parts.getOrNull(5) ?: ""
             val modelTypes = if (modelTypesStr.isNotBlank()) {
                 modelTypesStr.split(",").mapNotNull { typeStr ->


### PR DESCRIPTION
chore: Remove stale FIX comment from WorkProgressParser

The comment was pointing to an already implemented fix regarding parsing modelTypes string and is no longer an actionable TODO.

---
*PR created automatically by Jules for task [2289916656701325110](https://jules.google.com/task/2289916656701325110) started by @sean-brown-dev*