### PR TITLE
🧹 [Remove leftover debug println statements from whitespace tests]

### DIFF
--- a/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/domain/usecase/chat/ProcessThinkingTokensUseCaseWhitespaceTest.kt
+++ b/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/domain/usecase/chat/ProcessThinkingTokensUseCaseWhitespaceTest.kt
@@ -28,8 +28,6 @@ class ProcessThinkingTokensUseCaseWhitespaceTest {
 
         val thinkingText = state.thinkingTextToEmit
 
-        println("DEBUG thinking: '$thinkingText'")
-
         // Should preserve space after "2018" and "2020"
         assertFalse(
             thinkingText.contains("2018paper"),
@@ -50,8 +48,6 @@ class ProcessThinkingTokensUseCaseWhitespaceTest {
 
         val thinkingText = state.thinkingTextToEmit
 
-        println("DEBUG list thinking: '$thinkingText'")
-
         // Should preserve "1. First item" with space after period
         assertTrue(
             thinkingText.contains("1. First"),
@@ -71,8 +67,6 @@ class ProcessThinkingTokensUseCaseWhitespaceTest {
         val state = useCase("", "<think>The year is 2024 and counting.</think>", false)
 
         val thinkingText = state.thinkingTextToEmit
-
-        println("DEBUG year: '$thinkingText'")
 
         assertFalse(
             thinkingText.contains("2024and"),


### PR DESCRIPTION
🎯 **What:** Removed leftover debug `println` statements from `ProcessThinkingTokensUseCaseWhitespaceTest.kt`. 

💡 **Why:** Debug print statements in tests cause unnecessary standard output clutter during test suite execution. Removing them cleans up the logs and improves the signal-to-noise ratio for actual test failures. 

✅ **Verification:** Ran `./gradlew :core:domain:testDebugUnitTest --tests *ProcessThinkingTokensUseCaseWhitespaceTest*` to confirm the tests continue to pass without the print statements. Also ran `./gradlew ktlintCheck` and `./gradlew app:detekt --rerun-tasks` to ensure no formatting or static analysis regressions.

✨ **Result:** A cleaner test execution log and a removal of technical debt with zero changes to the underlying test assertions or application logic.

---
*PR created automatically by Jules for task [5270899211508140117](https://jules.google.com/task/5270899211508140117) started by @sean-brown-dev*