### PR TITLE
🧪 Add unit test for toMessagesState in GenerateChatResponseUseCase

### DIFF
--- a/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/domain/usecase/chat/GenerateChatResponseUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/com/browntowndev/pocketcrew/domain/usecase/chat/GenerateChatResponseUseCaseTest.kt
@@ -928,4 +928,62 @@ class GenerateChatResponseUseCaseTest {
         assertEquals(MessageState.THINKING, intermediateSnapshot.messageState)
         assertFalse(intermediateSnapshot.isComplete)
     }
+
+    @Test
+    fun `toMessagesState maps all current accumulators to snapshots`() = runTest {
+        // Given
+        val mockConfig = mockk<ModelConfiguration>()
+        every { modelRegistry.getRegisteredModelSync(any()) } returns mockConfig
+
+        var nextId = 3L
+        coEvery { chatRepository.createAssistantMessage(any(), any(), any(), any()) } answers { nextId++ }
+
+        val fakePipelineExecutor = FakePipelineExecutor()
+        // Add events for multiple models in the pipeline
+        fakePipelineExecutor.addProcessingEvent(ModelType.DRAFT_ONE)
+        fakePipelineExecutor.addGeneratingTextEvent("Draft one content", ModelType.DRAFT_ONE)
+        fakePipelineExecutor.addFinishedEvent(ModelType.DRAFT_ONE)
+        fakePipelineExecutor.addProcessingEvent(ModelType.DRAFT_TWO)
+        fakePipelineExecutor.addGeneratingTextEvent("Draft two content", ModelType.DRAFT_TWO)
+
+        val useCase = GenerateChatResponseUseCase(
+            inferenceFactory = inferenceFactory,
+            pipelineExecutor = fakePipelineExecutor,
+            chatRepository = chatRepository,
+            messageRepository = messageRepository,
+            loggingPort = loggingPort,
+            inferenceLockManager = InferenceLockManagerImpl(),
+            modelRegistry = modelRegistry
+        )
+
+        // When
+        val accumulatedMessages = mutableListOf<GenerateChatResponseUseCase.AccumulatedMessages>()
+        useCase(
+            prompt = "Hello",
+            userMessageId = 1L,
+            assistantMessageId = 2L,
+            chatId = 1L,
+            mode = Mode.CREW
+        ).collect { state ->
+            accumulatedMessages.add(state)
+        }
+
+        // Then - verify the final emitted state maps multiple current accumulators to snapshots
+        val finalState = accumulatedMessages.lastOrNull() ?: throw AssertionError("No accumulated messages")
+        assertEquals(2, finalState.messages.size)
+
+        // Verify DRAFT_ONE snapshot
+        val draftOneSnapshot = finalState.messages[2L]
+        assertNotNull(draftOneSnapshot)
+        assertEquals(ModelType.DRAFT_ONE, draftOneSnapshot!!.modelType)
+        assertEquals("Draft one content", draftOneSnapshot.content)
+        assertTrue(draftOneSnapshot.isComplete)
+
+        // Verify DRAFT_TWO snapshot
+        val draftTwoSnapshot = finalState.messages[3L]
+        assertNotNull(draftTwoSnapshot)
+        assertEquals(ModelType.DRAFT_TWO, draftTwoSnapshot!!.modelType)
+        assertEquals("Draft two content", draftTwoSnapshot.content)
+        assertFalse(draftTwoSnapshot.isComplete)
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the lack of explicit testing for the `toMessagesState` function within the `MessageAccumulatorManager` of `GenerateChatResponseUseCase`. The function is critical as it maps internal state-holding accumulators to immutable snapshots that are emitted to the UI via `Flow`.

📊 **Coverage:** What scenarios are now tested
A new test, `toMessagesState maps all current accumulators to snapshots`, has been added. It simulates a CREW mode execution where multiple models are engaged concurrently or sequentially (e.g., `DRAFT_ONE` and `DRAFT_TWO`), creating multiple active `MessageAccumulators`. The test verifies that `toMessagesState` correctly iterates over all items in the `_messages` map, calls `toSnapshot()` accurately on each, and returns an `AccumulatedMessages` state object containing the complete, multi-message payload without omissions or data mangling.

✨ **Result:** The improvement in test coverage
The previously untested function is now fully covered by verifying its behavior under complex, multi-message inference workloads. This ensures that the real-time UI flow will never silently drop a concurrent model's response update.

---
*PR created automatically by Jules for task [662959672167021772](https://jules.google.com/task/662959672167021772) started by @sean-brown-dev*