### PR TITLE
🎨 Palette: Add clear button to history search

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,0 @@
-## 2025-04-01 - [Jetpack Compose Accessibility: Redundant announcements]
-**Learning:** In Jetpack Compose, while interactive elements generally require a `contentDescription`, setting `contentDescription = null` on an `Icon` is correct and preferred when it is immediately accompanied by a descriptive `Text` component.
-**Action:** Always verify if an Icon is accompanied by text before adding a `contentDescription`. If text exists, leave `contentDescription` as null to avoid redundant screen reader announcements.


### PR DESCRIPTION
💡 What: Added a clear button (trailing icon) to the search field in `HistoryTopBar`.
🎯 Why: To allow users to quickly clear their search and see all history without mashing backspace, significantly improving the search UX.
♿ Accessibility: Included a clear `contentDescription = "Clear search"` for the new button.

---
*PR created automatically by Jules for task [10934033822031916383](https://jules.google.com/task/10934033822031916383) started by @sean-brown-dev*