### PR TITLE
🎨 Palette: Improve accessibility of MessageBubble

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,0 @@
-## 2024-05-24 - Accessibility for Interactive Surfaces
-**Learning:** Custom interactive surfaces in Jetpack Compose used for toggling visibility (like showing/hiding message actions) often lack semantic meaning for screen readers. Using just `Modifier.clickable` without a label leaves TalkBack users unaware of the action's purpose or current state.
-**Action:** Always provide an `onClickLabel` inside `Modifier.clickable` that dynamically updates based on the state (e.g., "Show message actions" vs "Hide message actions") to give screen reader users clear context about what the interaction does.


### PR DESCRIPTION
💡 **What**: Added `onClickLabel` to the `clickable` surface in `MessageBubble`.
🎯 **Why**: Improves accessibility for users relying on screen readers like TalkBack by announcing what the click action will do ("Show message actions" / "Hide message actions").
♿ **Accessibility**: Enhanced screen reader support for interactive message bubbles.

---
*PR created automatically by Jules for task [15491013278818603296](https://jules.google.com/task/15491013278818603296) started by @sean-brown-dev*