### PR TITLE
🎨 Palette: [UX] Add software keyboard navigation (ImeAction) to configuration forms

### DIFF
--- a/feature/settings/src/main/kotlin/com/browntowndev/pocketcrew/feature/settings/ByokConfigureScreen.kt
+++ b/feature/settings/src/main/kotlin/com/browntowndev/pocketcrew/feature/settings/ByokConfigureScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
@@ -309,7 +310,8 @@ fun CredentialsConfigurationForm(
             onValueChange = { onAssetChange(asset.copy(displayName = it)) },
             label = { Text("Display Name (e.g. My OpenAI)") },
             modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(12.dp)
+            shape = RoundedCornerShape(12.dp),
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
         )
 
         OutlinedTextField(
@@ -317,7 +319,8 @@ fun CredentialsConfigurationForm(
             onValueChange = { onAssetChange(asset.copy(modelId = it)) },
             label = { Text("Model ID (e.g. gpt-4o)") },
             modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(12.dp)
+            shape = RoundedCornerShape(12.dp),
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
         )
 
         OutlinedTextField(
@@ -326,6 +329,10 @@ fun CredentialsConfigurationForm(
             label = { Text("API Key") },
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(12.dp),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Password,
+                imeAction = if (asset.provider == ApiProvider.SELF_HOSTED) ImeAction.Next else ImeAction.Done
+            ),
             visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
             trailingIcon = {
                 IconButton(onClick = { passwordVisible = !passwordVisible }) {
@@ -343,7 +350,11 @@ fun CredentialsConfigurationForm(
                 onValueChange = { onAssetChange(asset.copy(baseUrl = it)) },
                 label = { Text("Base URL") },
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(12.dp)
+                shape = RoundedCornerShape(12.dp),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Uri,
+                    imeAction = ImeAction.Done
+                )
             )
         }
 
@@ -394,7 +405,8 @@ fun PresetConfigurationForm(
             onValueChange = { onConfigChange(config.copy(displayName = it)) },
             label = { Text("Preset Name (e.g. Creative)") },
             modifier = Modifier.padding(top = 16.dp).fillMaxWidth(),
-            shape = RoundedCornerShape(12.dp)
+            shape = RoundedCornerShape(12.dp),
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
         )
 
         OutlinedTextField(
@@ -421,7 +433,10 @@ fun PresetConfigurationForm(
                     }
                 },
                 shape = RoundedCornerShape(12.dp),
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Next
+                )
             )
 
             OutlinedTextField(
@@ -436,7 +451,10 @@ fun PresetConfigurationForm(
                     }
                 },
                 shape = RoundedCornerShape(12.dp),
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Next
+                )
             )
         }
 
@@ -454,7 +472,10 @@ fun PresetConfigurationForm(
             },
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(12.dp),
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Number,
+                imeAction = ImeAction.Done
+            )
         )
 
         TuningSlider(

--- a/feature/settings/src/main/kotlin/com/browntowndev/pocketcrew/feature/settings/ByokCustomHeadersScreen.kt
+++ b/feature/settings/src/main/kotlin/com/browntowndev/pocketcrew/feature/settings/ByokCustomHeadersScreen.kt
@@ -25,8 +25,10 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.activity.compose.BackHandler
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -157,7 +159,8 @@ fun HeaderRow(
             label = { Text("Name") },
             modifier = Modifier.weight(1f),
             shape = RoundedCornerShape(8.dp),
-            singleLine = true
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
         )
         OutlinedTextField(
             value = header.value,
@@ -165,7 +168,8 @@ fun HeaderRow(
             label = { Text("Value") },
             modifier = Modifier.weight(1.5f),
             shape = RoundedCornerShape(8.dp),
-            singleLine = true
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
         )
         IconButton(onClick = onDelete) {
             Icon(

--- a/feature/settings/src/main/kotlin/com/browntowndev/pocketcrew/feature/settings/LocalModelConfigureScreen.kt
+++ b/feature/settings/src/main/kotlin/com/browntowndev/pocketcrew/feature/settings/LocalModelConfigureScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -99,7 +100,8 @@ fun LocalModelConfigureScreen(
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(12.dp),
                 readOnly = config.isSystemPreset,
-                enabled = !config.isSystemPreset
+                enabled = !config.isSystemPreset,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
             )
 
             OutlinedTextField(
@@ -128,7 +130,10 @@ fun LocalModelConfigureScreen(
                     },
                     modifier = Modifier.weight(1f),
                     shape = RoundedCornerShape(12.dp),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Number,
+                        imeAction = ImeAction.Next
+                    ),
                     readOnly = config.isSystemPreset,
                     enabled = !config.isSystemPreset
                 )
@@ -145,7 +150,10 @@ fun LocalModelConfigureScreen(
                     },
                     modifier = Modifier.weight(1f),
                     shape = RoundedCornerShape(12.dp),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Number,
+                        imeAction = ImeAction.Next
+                    ),
                     readOnly = config.isSystemPreset,
                     enabled = !config.isSystemPreset
                 )
@@ -165,7 +173,10 @@ fun LocalModelConfigureScreen(
                 },
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(12.dp),
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Done
+                ),
                 readOnly = config.isSystemPreset,
                 enabled = !config.isSystemPreset
             )


### PR DESCRIPTION
💡 **What:** Added explicit `ImeAction` (Next, Done) and appropriate `KeyboardType` definitions to `OutlinedTextField` components across multiple settings configuration screens (`ByokConfigureScreen`, `LocalModelConfigureScreen`, `ByokCustomHeadersScreen`).

🎯 **Why:** Previously, these single-line text inputs relied on default keyboard behaviors. This meant that the software keyboard lacked a "Next" button, forcing users to manually dismiss the keyboard and tap the next field to continue entering data. By defining `ImeAction.Next`, users can now seamlessly tab through sequential form fields, significantly improving the intuitiveness and fluidity of configuration. `ImeAction.Done` was strategically applied to terminal fields. Multiline fields (like System Prompt) were kept default to ensure users can still type newlines.

♿ **Accessibility:** This improves navigation efficiency for all users interacting via on-screen software keyboards, reducing required physical taps and context switching.

📸 **Before/After:** (No visual layout changes, purely software keyboard behavioral update).

---
*PR created automatically by Jules for task [2105542959783761673](https://jules.google.com/task/2105542959783761673) started by @sean-brown-dev*