### PR TITLE
🧹 [code health improvement] Remove unused import LocalModelAsset from SettingsViewModelTest

### DIFF
--- a/app/src/main/kotlin/com/browntowndev/pocketcrew/PocketCrewApplication.kt
+++ b/app/src/main/kotlin/com/browntowndev/pocketcrew/PocketCrewApplication.kt
@@ -2,7 +2,6 @@ package com.browntowndev.pocketcrew
 import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
-import com.google.ai.edge.litertlm.ExperimentalApi
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 

--- a/app/src/main/kotlin/com/browntowndev/pocketcrew/app/ByokUseCasesModule.kt
+++ b/app/src/main/kotlin/com/browntowndev/pocketcrew/app/ByokUseCasesModule.kt
@@ -4,9 +4,9 @@ import com.browntowndev.pocketcrew.domain.usecase.byok.DeleteApiCredentialsUseCa
 import com.browntowndev.pocketcrew.domain.usecase.byok.DeleteApiCredentialsUseCaseImpl
 import com.browntowndev.pocketcrew.domain.usecase.byok.DeleteApiModelConfigurationUseCase
 import com.browntowndev.pocketcrew.domain.usecase.byok.DeleteApiModelConfigurationUseCaseImpl
-import com.browntowndev.pocketcrew.domain.usecase.byok.FetchApiProviderModelsUseCase
 import com.browntowndev.pocketcrew.domain.usecase.byok.FetchApiProviderModelDetailUseCase
 import com.browntowndev.pocketcrew.domain.usecase.byok.FetchApiProviderModelDetailUseCaseImpl
+import com.browntowndev.pocketcrew.domain.usecase.byok.FetchApiProviderModelsUseCase
 import com.browntowndev.pocketcrew.domain.usecase.byok.FetchApiProviderModelsUseCaseImpl
 import com.browntowndev.pocketcrew.domain.usecase.byok.GetApiModelAssetsUseCase
 import com.browntowndev.pocketcrew.domain.usecase.byok.GetApiModelAssetsUseCaseImpl
@@ -45,9 +45,7 @@ abstract class ByokUseCasesModule {
 
     @Binds
     @Singleton
-    abstract fun bindFetchApiProviderModelDetailUseCase(
-        impl: FetchApiProviderModelDetailUseCaseImpl
-    ): FetchApiProviderModelDetailUseCase
+    abstract fun bindFetchApiProviderModelDetailUseCase(impl: FetchApiProviderModelDetailUseCaseImpl): FetchApiProviderModelDetailUseCase
 
     @Binds
     @Singleton

--- a/app/src/main/kotlin/com/browntowndev/pocketcrew/app/EngineModule.kt
+++ b/app/src/main/kotlin/com/browntowndev/pocketcrew/app/EngineModule.kt
@@ -2,8 +2,8 @@ package com.browntowndev.pocketcrew.app
 
 import android.content.Context
 import com.browntowndev.pocketcrew.domain.port.inference.ConversationManagerPort
-import com.browntowndev.pocketcrew.domain.port.inference.LoggingPort
 import com.browntowndev.pocketcrew.domain.port.inference.InferenceFactoryPort
+import com.browntowndev.pocketcrew.domain.port.inference.LoggingPort
 import com.browntowndev.pocketcrew.domain.port.inference.ToolExecutorPort
 import com.browntowndev.pocketcrew.domain.port.repository.ActiveModelProviderPort
 import com.browntowndev.pocketcrew.domain.port.repository.LocalModelRepositoryPort
@@ -39,12 +39,13 @@ abstract class EngineModule {
             activeModelProvider: ActiveModelProviderPort,
             loggingPort: LoggingPort,
             toolExecutor: ToolExecutorPort,
-        ): ConversationManagerPort = ConversationManagerImpl(
-            context = context,
-            localModelRepository = localModelRepository,
-            activeModelProvider = activeModelProvider,
-            loggingPort = loggingPort,
-            toolExecutor = toolExecutor,
-        )
+        ): ConversationManagerPort =
+            ConversationManagerImpl(
+                context = context,
+                localModelRepository = localModelRepository,
+                activeModelProvider = activeModelProvider,
+                loggingPort = loggingPort,
+                toolExecutor = toolExecutor,
+            )
     }
 }

--- a/app/src/main/kotlin/com/browntowndev/pocketcrew/app/SettingsUseCasesModule.kt
+++ b/app/src/main/kotlin/com/browntowndev/pocketcrew/app/SettingsUseCasesModule.kt
@@ -1,6 +1,5 @@
 package com.browntowndev.pocketcrew.app
 
-import com.browntowndev.pocketcrew.domain.usecase.settings.SettingsUseCases
 import com.browntowndev.pocketcrew.domain.usecase.settings.SettingsApiProviderUseCases
 import com.browntowndev.pocketcrew.domain.usecase.settings.SettingsApiProviderUseCasesImpl
 import com.browntowndev.pocketcrew.domain.usecase.settings.SettingsAssignmentUseCases
@@ -11,6 +10,7 @@ import com.browntowndev.pocketcrew.domain.usecase.settings.SettingsLocalModelUse
 import com.browntowndev.pocketcrew.domain.usecase.settings.SettingsLocalModelUseCasesImpl
 import com.browntowndev.pocketcrew.domain.usecase.settings.SettingsPreferencesUseCases
 import com.browntowndev.pocketcrew.domain.usecase.settings.SettingsPreferencesUseCasesImpl
+import com.browntowndev.pocketcrew.domain.usecase.settings.SettingsUseCases
 import com.browntowndev.pocketcrew.domain.usecase.settings.SettingsUseCasesImpl
 import dagger.Binds
 import dagger.Module

--- a/app/src/test/kotlin/com/browntowndev/pocketcrew/testing/Fakes.kt
+++ b/app/src/test/kotlin/com/browntowndev/pocketcrew/testing/Fakes.kt
@@ -114,7 +114,7 @@ class FakeModelDownloadOrchestrator : ModelDownloadOrchestratorPort {
                         partialDownloads = emptyMap(),
                         allValid = true,
                     ),
-                availableToRedownload = emptyList()
+                availableToRedownload = emptyList(),
             )
         return startDownloads(modelsResult, wifiOnly)
     }

--- a/feature/settings/src/test/kotlin/com/browntowndev/pocketcrew/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/com/browntowndev/pocketcrew/feature/settings/SettingsViewModelTest.kt
@@ -5,7 +5,6 @@ import com.browntowndev.pocketcrew.core.ui.error.ViewModelErrorHandler
 import com.browntowndev.pocketcrew.domain.model.config.ApiCredentials
 import com.browntowndev.pocketcrew.domain.model.config.ApiModelAsset
 import com.browntowndev.pocketcrew.domain.model.config.ApiModelConfiguration
-import com.browntowndev.pocketcrew.domain.model.config.LocalModelAsset
 import com.browntowndev.pocketcrew.domain.model.config.LocalModelConfiguration
 import com.browntowndev.pocketcrew.domain.model.config.ApiCredentialsId
 import com.browntowndev.pocketcrew.domain.model.config.ApiModelConfigurationId


### PR DESCRIPTION
🎯 **What:** Removed the unused `LocalModelAsset` import from `SettingsViewModelTest.kt`, as well as addressing formatting errors using KtLint check on the file changes.
💡 **Why:** Unused imports clutter the codebase and increase cognitive overhead. Cleaning them up makes the code easier to read and maintain.
✅ **Verification:** Ran `./gradlew :feature:settings:testDebugUnitTest` to verify tests pass and no functionality was broken. Also ran `./gradlew ktlintCheck` to ensure code formatting remains correct.
✨ **Result:** A slightly cleaner and more maintainable `SettingsViewModelTest.kt` file.

---
*PR created automatically by Jules for task [13729548030835407721](https://jules.google.com/task/13729548030835407721) started by @sean-brown-dev*