### PR TITLE
⚡ Bolt: [performance improvement] Pre-compile Regex in SettingsUiMappers

### DIFF
--- a/feature/settings/src/main/kotlin/com/browntowndev/pocketcrew/feature/settings/SettingsUiMappers.kt
+++ b/feature/settings/src/main/kotlin/com/browntowndev/pocketcrew/feature/settings/SettingsUiMappers.kt
@@ -54,6 +54,12 @@ class ApiModelAssetUiMapper @Inject constructor() {
     )
 }
 
+private object LocalModelAssetConstants {
+    val dashGgufRegex = Regex("-GGUF$", RegexOption.IGNORE_CASE)
+    val dotGgufRegex = Regex("\\.gguf$", RegexOption.IGNORE_CASE)
+    val dotLitertlmRegex = Regex("\\.litertlm$", RegexOption.IGNORE_CASE)
+}
+
 class LocalModelAssetUiMapper @Inject constructor() {
     fun map(asset: LocalModelAsset): LocalModelAssetUi {
         val rawName = asset.metadata.huggingFaceModelName
@@ -68,9 +74,9 @@ class LocalModelAssetUiMapper @Inject constructor() {
         }
 
         val cleanName = modelNamePart
-            .replace(Regex("-GGUF$", RegexOption.IGNORE_CASE), "")
-            .replace(Regex("\\.gguf$", RegexOption.IGNORE_CASE), "")
-            .replace(Regex("\\.litertlm$", RegexOption.IGNORE_CASE), "")
+            .replace(LocalModelAssetConstants.dashGgufRegex, "")
+            .replace(LocalModelAssetConstants.dotGgufRegex, "")
+            .replace(LocalModelAssetConstants.dotLitertlmRegex, "")
             .replace("-", " ")
 
         return LocalModelAssetUi(


### PR DESCRIPTION
💡 **What:** Extracted three `Regex` instances into a `private object LocalModelAssetConstants` in `SettingsUiMappers.kt`. 
🎯 **Why:** Previously, these three regular expressions were instantiated and compiled inline inside `LocalModelAssetUiMapper.map`. Because this mapping function is typically applied in a loop mapping over a list of configurations, it triggered continuous reallocation and runtime compilation of regex expressions.
📊 **Impact:** Reduces CPU overhead by caching the compiled regex patterns in a singleton context instead of creating them dynamically on every list map evaluation. O(1) creation instead of O(N).
🔬 **Measurement:** Verify tests run successfully using `./gradlew testDebugUnitTest`. Run lint checks via `./gradlew ktlintCheck`.

---
*PR created automatically by Jules for task [5272593653938081756](https://jules.google.com/task/5272593653938081756) started by @sean-brown-dev*