### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in file download

### DIFF
--- a/core/data/src/main/kotlin/com/browntowndev/pocketcrew/core/data/download/ModelDownloadWorker.kt
+++ b/core/data/src/main/kotlin/com/browntowndev/pocketcrew/core/data/download/ModelDownloadWorker.kt
@@ -17,6 +17,7 @@ import com.browntowndev.pocketcrew.domain.model.download.totalArtifactSizeInByte
 import com.browntowndev.pocketcrew.domain.port.download.FileDownloaderPort
 import com.browntowndev.pocketcrew.domain.port.download.ModelUrlProviderPort
 import com.browntowndev.pocketcrew.domain.port.inference.LoggingPort
+import com.browntowndev.pocketcrew.core.data.download.remote.DownloadSecurity
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.serialization.decodeFromString
@@ -243,7 +244,7 @@ class ModelDownloadWorker @AssistedInject constructor(
 
         // Check if all artifacts already exist
         val allArtifactsPresent = artifacts.all { artifact ->
-            val targetFile = File(targetDir, artifact.localFileName)
+            val targetFile = DownloadSecurity.resolveDownloadPaths(targetDir, artifact.localFileName).targetFile
             targetFile.exists() && targetFile.length() == artifact.sizeInBytes
         }
         if (allArtifactsPresent) {
@@ -287,13 +288,14 @@ class ModelDownloadWorker @AssistedInject constructor(
                     "[DOWNLOAD] Starting download: url=$downloadUrl, remoteFileName=${artifact.remoteFileName}, localFileName=${artifact.localFileName}"
                 )
 
-                val targetFile = File(targetDir, artifact.localFileName)
+                val paths = DownloadSecurity.resolveDownloadPaths(targetDir, artifact.localFileName)
+                val targetFile = paths.targetFile
                 if (targetFile.exists() && targetFile.length() == artifact.sizeInBytes) {
                     completedBytes += artifact.sizeInBytes
                     return@forEach
                 }
 
-                val tempFile = File(targetDir, "${artifact.localFileName}${ModelConfig.TEMP_EXTENSION}")
+                val tempFile = paths.tempFile
                 val existingBytes = if (tempFile.exists()) tempFile.length() else 0L
                 val downloadConfig = FileDownloaderPort.FileDownloadConfig(
                     filename = artifact.localFileName,

--- a/core/data/src/main/kotlin/com/browntowndev/pocketcrew/core/data/download/UtilityModelFileResolver.kt
+++ b/core/data/src/main/kotlin/com/browntowndev/pocketcrew/core/data/download/UtilityModelFileResolver.kt
@@ -34,13 +34,18 @@ class UtilityModelFileResolver @Inject constructor(
         }
     }
 
+    private fun isSafeChildOf(child: File, parent: File): Boolean {
+        val childCanonical = child.canonicalPath
+        val parentCanonical = parent.canonicalPath + File.separator
+        return childCanonical.startsWith(parentCanonical)
+    }
+
     private fun safeFile(parentDir: File, filename: String): File {
         require(filename.isNotBlank()) { "Utility model filename must not be blank." }
 
         val safeName = File(filename).name
         val resolvedFile = File(parentDir, safeName)
-        val parentPath = parentDir.canonicalPath + File.separator
-        require(resolvedFile.canonicalPath.startsWith(parentPath)) {
+        require(isSafeChildOf(resolvedFile, parentDir)) {
             "Resolved utility model path escapes model directory."
         }
         return resolvedFile

--- a/core/data/src/main/kotlin/com/browntowndev/pocketcrew/core/data/download/remote/DownloadSecurity.kt
+++ b/core/data/src/main/kotlin/com/browntowndev/pocketcrew/core/data/download/remote/DownloadSecurity.kt
@@ -79,14 +79,19 @@ internal object DownloadSecurity {
         val safeFileName = requireSafeFileName(fileName)
         val canonicalTargetDir = targetDir.canonicalFile
 
+        fun isSafeChildOf(child: File, parent: File): Boolean {
+            val childCanonical = child.canonicalPath
+            val parentCanonical = parent.canonicalPath + File.separator
+            return childCanonical.startsWith(parentCanonical)
+        }
+
         fun resolveChild(name: String): File {
-            val resolved = File(canonicalTargetDir, name).canonicalFile
-            if (resolved.parentFile != canonicalTargetDir) {
+            val resolved = File(canonicalTargetDir, File(name).name).canonicalFile
+            if (!isSafeChildOf(resolved, canonicalTargetDir)) {
                 throw SecurityException("Resolved path escapes target directory: $name")
             }
             return resolved
         }
-
         return DownloadPaths(
             targetFile = resolveChild(safeFileName),
             tempFile = resolveChild("$safeFileName${ModelConfig.TEMP_EXTENSION}"),


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unchecked `artifact.localFileName` variables from potentially remote configurations were directly resolved against base directories via `File(dir, fileName)`, permitting arbitrary file writes and system disruption via `../` traversal sequences.
🎯 **Impact:** Allowed an attacker crafting malicious remote Model configurations to overwrite any file the application has access to.
🔧 **Fix:** Refactored `ModelDownloadWorker` to utilize `DownloadSecurity.resolveDownloadPaths` globally for temp, target, and meta files. Strengthened internal validation logic in `DownloadSecurity` and `UtilityModelFileResolver` to explicitly compare canonical directory prefixes and enforce baseline filename flattening before attempting path construction.
✅ **Verification:** Ran `./gradlew testDebugUnitTest` and validated that downloads securely enforce directory scoping logic.

---
*PR created automatically by Jules for task [1843049016860930189](https://jules.google.com/task/1843049016860930189) started by @sean-brown-dev*